### PR TITLE
Updating dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ local.properties
 
 # OSX files
 .DS_Store
+projectFilesBackup/.idea/workspace.xml

--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,3 @@ local.properties
 
 # OSX files
 .DS_Store
-projectFilesBackup/.idea/workspace.xml

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,16 +5,15 @@ buildscript {
     }
     dependencies {
         classpath 'com.github.ben-manes:gradle-versions-plugin:0.12.0'
-        classpath 'com.google.gms:google-services:2.1.0-alpha3'
+        classpath 'com.google.gms:google-services:3.0.0'
         classpath 'com.jakewharton.hugo:hugo-plugin:1.2.1'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
-        classpath 'io.fabric.tools:gradle:1.21.5'
+        classpath 'io.fabric.tools:gradle:1.21.7'
         classpath 'me.tatarka:gradle-retrolambda:3.2.5'
     }
 }
 
 apply plugin: 'com.android.application'
-
 apply plugin: 'com.github.ben-manes.versions'
 apply plugin: 'com.neenbedankt.android-apt'
 apply plugin: 'com.jakewharton.hugo'
@@ -31,12 +30,12 @@ repositories {
 }
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion '23.0.2'
+    compileSdkVersion 24
+    buildToolsVersion '24.0.0'
     defaultConfig {
         applicationId 'com.xmartlabs.template'
         minSdkVersion 17
-        targetSdkVersion 23
+        targetSdkVersion 24
         versionCode 1
         versionName '0.1.0'
     }
@@ -109,61 +108,80 @@ android {
     }
 }
 
+final ANDROID_SUPPORT_VERSION = '24.0.0'
+final BULLET_VERSION = 'e5044b53df'
+final BUTTER_KNIFE_VERSION = '8.1.0'
+final DAGGER_VERSION = '2.5'
+final DART_VERSION = '2.0.0'
+final DB_FLOW_VERSION = '3.0.1'
+final FRAGMENT_ARGS_VERSION = '3.0.2'
+final LOMBOK_VERSION = '1.16.8'
+final OK_HTTP_VERSION = '3.3.1'
+final OKIO_VERSION = '1.8.0'
+final PARCELER_VERSION = '1.1.5'
+final RETROFIT_VERSION = '2.1.0'
+final RX_LIFECYCLE_VERSION = '0.6.1'
+final FIREBASE_VERSION = '9.0.2'
+
 dependencies {
     androidTestCompile 'com.jayway.android.robotium:robotium-solo:5.5.4'
-    androidTestCompile 'org.mockito:mockito-core:2.0.44-beta'
-    apt 'com.f2prateek.dart:dart-processor:2.0.0'
-    apt 'com.f2prateek.dart:henson-processor:2.0.0'
-    apt "com.github.Raizlabs.DBFlow:dbflow-processor:3.0.0-beta5"
-    apt 'com.github.tbroyer.bullet:bullet-compiler:e5044b53df'
-    provided 'com.google.dagger:dagger-compiler:2.0.2'
-    apt 'com.hannesdorfmann.fragmentargs:processor:3.0.2'
+    androidTestCompile 'org.mockito:mockito-core:2.0.70-beta'
+    apt "com.f2prateek.dart:dart-processor:${DART_VERSION}"
+    apt "com.f2prateek.dart:henson-processor:${DART_VERSION}"
+    apt "com.github.Raizlabs.DBFlow:dbflow-processor:${DB_FLOW_VERSION}"
+    apt "com.github.tbroyer.bullet:bullet-compiler:${BULLET_VERSION}"
+    provided "com.google.dagger:dagger-compiler:${DAGGER_VERSION}"
+    apt "com.hannesdorfmann.fragmentargs:processor:${FRAGMENT_ARGS_VERSION}"
+    apt "com.jakewharton:butterknife-compiler:${BUTTER_KNIFE_VERSION}"
     //apt 'net.ltgt.dagger:bullet-compiler:1.0-SNAPSHOT' // Loaded from JitPack
-    apt 'org.parceler:parceler:1.0.4'
-    apt 'org.projectlombok:lombok:1.16.6'
-    compile 'com.android.support:appcompat-v7:23.2.0'
-    compile 'com.android.support:cardview-v7:23.2.0'
-    compile 'com.android.support:design:23.2.0'
-    compile 'com.android.support:recyclerview-v7:23.2.0'
-    compile 'com.android.support:support-v13:23.2.0'
-    compile 'com.annimon:stream:1.0.8'
-    compile('com.crashlytics.sdk.android:crashlytics:2.5.5@aar') {
+    apt "org.parceler:parceler:${PARCELER_VERSION}"
+    apt "org.projectlombok:lombok:${LOMBOK_VERSION}"
+    compile "com.android.support:appcompat-v7:${ANDROID_SUPPORT_VERSION}"
+    compile "com.android.support:cardview-v7:${ANDROID_SUPPORT_VERSION}"
+    compile "com.android.support:design:${ANDROID_SUPPORT_VERSION}"
+    compile "com.android.support:recyclerview-v7:${ANDROID_SUPPORT_VERSION}"
+    compile "com.android.support:support-v13:${ANDROID_SUPPORT_VERSION}"
+    compile 'com.annimon:stream:1.0.9'
+    compile('com.crashlytics.sdk.android:crashlytics:2.5.7@aar') {
         transitive = true
     }
-    compile 'com.f2prateek.dart:dart:2.0.0'
-    compile 'com.f2prateek.dart:henson:2.0.0'
+    compile "com.f2prateek.dart:dart:${DART_VERSION}"
+    compile "com.f2prateek.dart:henson:${DART_VERSION}"
     compile 'com.github.mrmike:Ok2Curl:0.2.3'
-    compile "com.github.Raizlabs.DBFlow:dbflow-core:3.0.0-beta5"
-    compile "com.github.Raizlabs.DBFlow:dbflow:3.0.0-beta5"
+    compile "com.github.Raizlabs.DBFlow:dbflow-core:${DB_FLOW_VERSION}"
+    compile "com.github.Raizlabs.DBFlow:dbflow:${DB_FLOW_VERSION}"
     compile 'com.github.square.picasso:picasso:8c16e8564e'
-    compile 'com.github.tbroyer.bullet:bullet:e5044b53df'
-    compile 'com.google.android.gms:play-services-gcm:8.4.0'
-    compile 'com.google.dagger:dagger:2.0.2'
-    compile 'com.hannesdorfmann.fragmentargs:annotation:3.0.2'
-    compile 'com.hannesdorfmann.fragmentargs:bundler-parceler:3.0.2'
-    compile 'com.jakewharton:butterknife:7.0.1'
-    compile 'com.jakewharton.timber:timber:4.1.1'
-    compile 'com.squareup.okhttp3:okhttp:3.2.0'
-    compile 'com.squareup.okhttp3:logging-interceptor:3.2.0'
-    compile 'com.squareup.okio:okio:1.6.0'
+    compile "com.github.tbroyer.bullet:bullet:${BULLET_VERSION}"
+    compile "com.google.dagger:dagger:${DAGGER_VERSION}"
+    compile "com.google.firebase:firebase-core:${FIREBASE_VERSION}"
+    compile "com.google.firebase:firebase-invites:${FIREBASE_VERSION}"
+    compile "com.google.firebase:firebase-messaging:${FIREBASE_VERSION}"
+    compile "com.hannesdorfmann.fragmentargs:annotation:${FRAGMENT_ARGS_VERSION}"
+    compile "com.hannesdorfmann.fragmentargs:bundler-parceler:${FRAGMENT_ARGS_VERSION}"
+    compile "com.jakewharton:butterknife:${BUTTER_KNIFE_VERSION}"
+    compile 'com.jakewharton.timber:timber:4.1.2'
+    compile "com.squareup.okhttp3:okhttp:${OK_HTTP_VERSION}"
+    compile "com.squareup.okhttp3:logging-interceptor:${OK_HTTP_VERSION}"
+    compile "com.squareup.okio:okio:${OKIO_VERSION}"
     //compile 'com.squareup.picasso:picasso:2.5.2' // Loaded from JitPack in order to use OkHttp3
-    compile 'com.squareup.retrofit2:converter-gson:2.0.0'
-    compile 'com.squareup.retrofit2:adapter-rxjava:2.0.0'
-    compile 'com.squareup.retrofit2:retrofit:2.0.0'
-    compile 'com.trello:rxlifecycle:0.5.0'
-    compile 'com.trello:rxlifecycle-components:0.5.0'
+    compile "com.squareup.retrofit2:converter-gson:${RETROFIT_VERSION}"
+    compile "com.squareup.retrofit2:adapter-rxjava:${RETROFIT_VERSION}"
+    compile "com.squareup.retrofit2:retrofit:${RETROFIT_VERSION}"
+    compile "com.trello:rxlifecycle:${RX_LIFECYCLE_VERSION}"
+    compile "com.trello:rxlifecycle-components:${RX_LIFECYCLE_VERSION}"
     compile 'com.viewpagerindicator:library:2.4.1@aar'
-    compile 'io.reactivex:rxandroid:1.1.0@aar'
-    compile 'io.reactivex:rxjava:1.1.2'
+    compile 'io.reactivex:rxandroid:1.2.1@aar'
+    compile 'io.reactivex:rxjava:1.1.6'
     //compile 'net.ltgt.dagger:bullet:1.0-SNAPSHOT' // Loaded from JitPack
-    compile 'org.parceler:parceler-api:1.0.4'
+    compile "org.parceler:parceler-api:${PARCELER_VERSION}"
     compile fileTree(include: ['*.jar'], dir: 'libs')
-    provided 'org.projectlombok:lombok:1.16.8'
+    provided "org.projectlombok:lombok:${LOMBOK_VERSION}"
     testCompile 'junit:junit:4.12'
-    testCompile 'org.robolectric:robolectric:3.0'
+    testCompile 'org.robolectric:robolectric:3.1'
 }
 
-// Uncomment when having the google-services.json files
+apply plugin: 'com.google.gms.google-services'
+
 /*apply plugin: 'com.google.gms.google-services'
 
 def appModuleRootFolder = '.'

--- a/app/src/main/java/com/xmartlabs/template/BaseProjectApplication.java
+++ b/app/src/main/java/com/xmartlabs/template/BaseProjectApplication.java
@@ -4,6 +4,7 @@ import android.app.Application;
 
 import com.crashlytics.android.Crashlytics;
 import com.crashlytics.android.core.CrashlyticsCore;
+import com.raizlabs.android.dbflow.config.FlowConfig;
 import com.raizlabs.android.dbflow.config.FlowManager;
 import com.xmartlabs.template.helper.GeneralErrorHelper;
 import com.xmartlabs.template.module.AndroidModule;
@@ -44,7 +45,7 @@ public class BaseProjectApplication extends Application {
   }
 
   private void initializeDataBase() {
-    FlowManager.init(this);
+    FlowManager.init(new FlowConfig.Builder(this).build());
   }
 
   private void initializeInjections() {

--- a/app/src/main/java/com/xmartlabs/template/ui/BaseFragment.java
+++ b/app/src/main/java/com/xmartlabs/template/ui/BaseFragment.java
@@ -18,12 +18,14 @@ import com.xmartlabs.template.BaseProjectApplication;
 import com.xmartlabs.template.R;
 
 import butterknife.ButterKnife;
+import butterknife.Unbinder;
 
 /**
  * Created by santiago on 15/09/15.
  */
 @FragmentWithArgs
 public abstract class BaseFragment extends RxFragment {
+  private Unbinder unbinder;
   @Nullable
   private ProgressDialog progressDialog;
 
@@ -33,9 +35,7 @@ public abstract class BaseFragment extends RxFragment {
   @Override
   public void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
-
     FragmentArgs.inject(this);
-
     BaseProjectApplication.getContext().inject(this);
   }
 
@@ -43,7 +43,7 @@ public abstract class BaseFragment extends RxFragment {
   @Override
   public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
     View view = inflater.inflate(getLayoutResId(), container, false);
-    ButterKnife.bind(this, view);
+    unbinder = ButterKnife.bind(this, view);
 
     return view;
   }
@@ -68,7 +68,7 @@ public abstract class BaseFragment extends RxFragment {
   @Override
   public void onDestroyView() {
     super.onDestroyView();
-    ButterKnife.unbind(this);
+    unbinder.unbind();
   }
 
   protected void showAlertError(int stringResId) {

--- a/app/src/main/java/com/xmartlabs/template/ui/MainActivity.java
+++ b/app/src/main/java/com/xmartlabs/template/ui/MainActivity.java
@@ -7,15 +7,18 @@ import android.support.v7.widget.Toolbar;
 import com.f2prateek.dart.*;
 import com.xmartlabs.template.R;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
+import butterknife.Unbinder;
 
 /**
  * Created by santiago on 03/03/16.
  */
 @HensonNavigable
 public class MainActivity extends BaseAppCompatActivity {
-  @Bind(R.id.toolbar)
+  private Unbinder unbinder;
+
+  @BindView(R.id.toolbar)
   Toolbar toolbar;
 
   @Override
@@ -23,8 +26,14 @@ public class MainActivity extends BaseAppCompatActivity {
     super.onCreate(savedInstanceState);
 
     setContentView(R.layout.activity_main);
-    ButterKnife.bind(this);
+    unbinder = ButterKnife.bind(this);
 
     setSupportActionBar(toolbar);
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    unbinder.unbind();
   }
 }

--- a/app/src/main/java/com/xmartlabs/template/ui/SingleFragmentWithToolbarActivity.java
+++ b/app/src/main/java/com/xmartlabs/template/ui/SingleFragmentWithToolbarActivity.java
@@ -7,14 +7,14 @@ import android.support.v7.widget.Toolbar;
 
 import com.xmartlabs.template.R;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 
 /**
  * Created by santiago on 31/08/15.
  */
 public abstract class SingleFragmentWithToolbarActivity extends SingleFragmentActivity {
-  @Bind(R.id.toolbar)
+  @BindView(R.id.toolbar)
   Toolbar toolbar;
 
   protected int getLayoutResId() {

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0-alpha3'
+        classpath 'com.android.tools.build:gradle:2.1.0'
     }
 }
 


### PR DESCRIPTION
# Crashlytics

**2.5.7**
Update Crashlytics Core and Answers dependency
**2.5.6**
Updated Fabric dependency
# DBFlow

**3.0.1**
Fixes issue where AsyncModel operations did not actually operate on its associated Model.
Fix code gen for overridden Update, Insert, delete ops where passing in DatabaseWrapper did not honor @OneToMany annotation.
Fix issue where ListModelSaver ignores caching rules.

**3.0.0**

This release incorporates a host and slew of improvements. A large chunk of the library has been rewritten, reworked, and improved significantly.

New Features

Properties: Instead of generated column String names, Property simplify queries even further and provide type-safety.
Transactions Rewritten: Transactions have been rewritten from the ground-up to provide flexibility, better syntax, and easy customization. You can even swap out the library's system and replace it with your own.
Database Encryption Support: via SQLCipher enables secure databases with minimal configuration and effort in DBFlow!
Usage Docs: I rewrote usage docs to be more comprehensive and informative.
Foreign Keys Simplified: no longer do you have to manually specify @ForeignKey references.
Caching with Multiple Primary Keys: Caching now supports multiple primary keys and keys of any supported type.
Database Modules: DBFlow is supported in multiple application projects via modules. This enables sharing of Databases and their associated files.
Better Code Generation: Support package private fields from different packages, better error messaging during compile phase, significant code gen improvements, and more.
Kotlin Extensions Support: Via dbflow-kotlinextensions allows you to write better DBFlow code in Kotlin.
New SQLite features supported such as Case, CAST, and more!
Many bug fixes, code comment improvements, code generation improvements, and more.

**Pre-release**
**3.0.0-beta6**

Ideally this will be the final beta before 3.0 goes live. The next release should incorporate any more bugs or issues found in 3.0, so keep reporting!

This release contains three significant updates:

Initialization of DBFlow has changed. Now configuration of ModelAdapter, @Database, and other classes can mostly be done through the new FlowConfig.Builder class. For a simple example, view an example here
The transactions system got a complete and utter overhaul. Welcome the Transaction.Builder! Each Transaction contains Success and Error callbacks for easy listening. See the migration guide for guidance. By default, we no longer use a priority-based queue for transactions. To keep that, read here. You can now also specify and roll your own ITransactionQueue or BaseTransactionManager, read up here.
I rewrote the documentation completely for accuracy and for better organization. I hope you like!
Some new features:

Can now use the CASE Operator! `SQLite.
SQLite.select(CaseModel_Table.customerId,
                CaseModel_Table.firstName,
                CaseModel_Table.lastName,
                SQLite.caseWhen(CaseModel_Table.country.eq("USA"))
                        .then("Domestic")
                        ._else("Foreign").end("CustomerGroup")).from(CaseModel.class);
Can Collate.LOCALIZED and Collate.UNICODE
Can now multipliedBy(), add(), dividedBy(), mod(), and concatenate() IProperty together.
This release contains a number of bug fixes as well here](https://github.com/Raizlabs/DBFlow/issues?q=milestone%3A3.0.0-beta6+is%3Aclosed)
# Dagger 2 (Components)

**Version 2.5 (2016-06-14)**

Enables @Binds usage with multibinding annotations (@IntoSet, @ElementsIntoSet, and @IntoMap)
Adds @Multibinds API to replace @Multibindings interfaces
@Component.Builder methods for abstract modules are no longer allowed
Performance improvements for @IntoSet usage. Provided objects are no longer wrapped in a wasteful Collections.singleton()
Compilation speed improvements for large graphs
@Scopes are no longer allowed on @Produces methods
Adds state checking to scoped providers to make sure a circular dependency does not create multiple instances
Producers optimizations: Each @Produces method now generates 1 class instead of 2
Fix: Requests for Map now include both @Provides @IntoMap and @Produces @IntoMap values

**Version 2.4 (2016-04-21)**

Adds @Binds API for delegating one binding to another
Adds @IntoSet, @ElementsIntoSet and @IntoMap to replace @Provides(type = ...) and @Produces(type = ...)
Allow injection of Provider<Lazy<Foo>>
Report an error if a @Scope annotation is applied to an @Inject constructor
Remove the ability to set the production executor on a component builder.
Ensure that no binding methods are binding framework types.
New format of dependency traces in error messages
Fixed bug: Exception when a binding in a parent that is used only in a subcomponent depends on a binding in the subcomponent
Update to JavaPoet 1.6.1 and Google Java Format 1.0
Fixes NoSuchMethodError from Issue #356
Version 2.3 (2016-04-08)

Adds @Reusable scope (javadoc)

**Version 2.2 (2016-03-22)**

dagger.mapkeys moved to dagger.multibindings and all @MapKey implementations now correctly have @Beta applied
Better error messages for multibindings
Compiler bug fixes!

**Version 2.1 (2016-03-10)**

Correctly handle @Components that inject generated types
Adds @ProductionSubcomponent and @ProductionScope
Allow the production Executor to be bound with @Production
Allow multiple scope annotations on components
A component's subcomponents’ (and their subcomponents’) simple names no longer need to be unique
Adds the ability to depend on subcomponent builders
GWT Integration
Producers monitoring
Multibindings for producers
Add common @MapKey annotations to dagger.mapkeys. These annotations are not, but should be marked @Beta (since the @MapKey itself is beta).
Lots of bug fixes!
# ButterKnife

**Version 8.1.0 (2016-06-14)**

New: Change the structure of generated view binders to optimize for performance and generated code. This should result in faster binding (not that it's slow) and a reduction of methods.
Fix: Call the correct method on TextView to unbind @OnTextChanged uses.
Fix: Properly handle package names which contain uppercase letters.
Version 8.0.1 (2016-04-27)

Fix: ProGuard rules now prevent obfuscation of only types which reference ButterKnife annotations.
Eliminate some of the generated machinery when referenced from final types.

**Version 8.0.0 (2016-04-25)**

@Bind becomes @BindView and @BindViews (one view and multiple views, respectively).
Calls to bind now return an Unbinder instance which can be used to null references. This replaces the unbind API and adds support for being able to clear listeners.
New: @BindArray binds String, CharSequence, and int arrays and TypeArray to fields.
New: @BindBitmap binds Bitmap instances from resources to fields.
@BindDrawable now supports a tint field which accepts a theme attribute.
The runtime and compiler are now split into two artifacts.

compile 'com.jakewharton:butterknife:8.0.0'
apt 'com.jakewharton:butterknife-compiler:8.0.0'
New: apply overloads which accept a single view and arrays of views.
ProGuard rules now ship inside of the library and are included automatically.
@Optional annotation is back to mark methods as being optional.
# Timber

**Version 4.1.2 (2016-03-30)**

Fix: Tag-length lint check now only triggers on calls to Timber's tag method. Previously it would match any tag method and flag arguments longer than 23 characters.
# OkHttp

**Version 3.3.1**

2016-05-28

Fix: The plaintext check in HttpLoggingInterceptor incorrectly classified newline characters as control characters. This is fixed.
Fix: Don't crash reading non-ASCII characters in HTTP/2 headers or in cached HTTP headers.
Fix: Retain the response body when an attempt to open a web socket returns a non-101 response code.

**Version 3.3.0**

2016-05-24

New: Response.sentRequestAtMillis() and receivedResponseAtMillis() methods track the system's local time when network calls are made. These replace the OkHttp-Sent-Millis and OkHttp-Received-Millis headers that were present in earlier versions of OkHttp.
New: Accept user-provided trust managers in OkHttpClient.Builder. This allows OkHttp to satisfy its TLS requirements directly. Otherwise OkHttp will use reflection to extract the TrustManager from the SSLSocketFactory.
New: Support prerelease Java 9. This gets ALPN from the platform rather than relying on the alpn-boot bootclasspath override.
New: HttpLoggingInterceptor now logs connection failures.
New: Upgrade to Okio 1.8.0.

 <dependency>
   <groupId>com.squareup.okio</groupId>
   <artifactId>okio</artifactId>
   <version>1.8.0</version>
 </dependency>
Fix: Gracefully recover from a failure to rebuild the cache journal.

Fix: Don't corrupt cache entries when a cache entry is evicted while it is being updated.
Fix: Make logging more consistent throughout OkHttp.
Fix: Log plaintext bodies only. This uses simple heuristics to differentiate text from other data.
Fix: Recover from REFUSED_STREAM errors in HTTP/2. This should improve interoperability with Nginx 1.10.0, which refuses streams created before HTTP/2 settings have been acknowledged.
Fix: Improve recovery from failed routes.
Fix: Accommodate tunneling proxies that close the connection after an auth challenge.
Fix: Use the proxy authenticator when authenticating HTTP proxies. This regression was introduced in OkHttp 3.0.
Fix: Fail fast if network interceptors transform the response body such that closing it doesn't also close the underlying stream. We had a bug where OkHttp would attempt to reuse a connection but couldn't because it was still held by a prior request.
Fix: Ensure network interceptors always have access to the underlying connection.
Fix: Use X509TrustManagerExtensions on Android 17+.
Fix: Unblock waiting dispatchers on MockWebServer shutdown.
# Retrofit

**Version 2.1.0 (2016-06-15)**

New: @HeaderMap annotation and support for supplying an arbitrary number of headers to an endpoint.
New: @JsonAdapter annotations on the @Body parameter and on the method will be propagated to Moshi for creating the request and response adapters, respectively.
Fix: Honor the Content-Type encoding of XML responses when deserializing response bodies.
Fix: Remove the stacktrace from fake network exceptions created from retrofit-mock's NetworkBehavior. They had the potential to be misleading and look like a library issue.
Fix: Eagerly catch malformed Content-Type headers supplied via @Header or @Headers.
Version 2.0.2 (2016-04-14)

New: ProtoConverterFactory.createWithRegistry() method accepts an extension registry to be used when deserializing protos.
Fix: Pass the correct Call instance to Callback's onResponse and onFailure methods such that calling clone() retains the correct threading behavior.
Fix: Reduce the per-request allocation overhead for the RxJava call adapter.
Version 2.0.1 (2016-03-30)

New: Support OkHttp's HttpUrl as a @Url parameter type.
New: Support iterable and array @Part parameters using OkHttp's MultipartBody.Part.
Fix: Honor backpressure in Observables created from the RxJavaCallAdapterFactory.
# RxLifeCycle

**0.6.1 (2016-05-11)**
#118: Use LifecycleTransformer in the provider interfaces

**0.6.0 (2016-05-06)**

Added LifecycleTransformer, which provides Single and Completable support.
#111: Added component support for AppCompatDialogFragment
#107: Fixed navi component package
# RxAndroid

**1.2.1**
Version 1.2.1

 **1.2.0**
@JakeWharton JakeWharton released this on May 3 · 14 commits to master since this release

Rewrite the Android-specific schedulers (main thread or custom) to greatly reduce allocation and performance overhead of scheduling work.
HandlerScheduler.create has been deprecated in favor of AndroidSchedulers.from(Looper) as a Looper is the actual mechanism of scheduling on Android, not Handler.
Fix: Correct the behavior of AndroidSchedulers.mainThread() to only invoke the registered RxAndroidSchedulersHook for creating the main thread scheduler and to cache the result instead of invoking it every time. This behvior change eliminates a performance overhead and brings behavior in line with RxJava. If you were relying on the ability to change the main thread scheduler over time (such as for tests), return a delegating scheduler from the hook which allows changing the delegate instance at will.
RxJava dependency now points at v1.1.4.
RxAndroidPlugins.reset() is now marked as @Experimental to match the RxJava method of the same name and behavior.
# RxJava

**1.1.6**
@stevegury stevegury released this 9 days ago · 28 commits to 1.x since this release

Version 1.1.6 - June 15, 2016 (Maven)

API enhancements

Pull 3934: TestSubscriber extra info on assertion failures
Pull 3948: add Completable.andThen(Completable)
Pull 3942: add Completable.subscribe to be safe, add unsafeSubscribe option + RxJavaPlugins hook support
Pull 3936: promote UnicastSubject to be a standard+experimental Subject
Pull 3971: add Observable.rebatchRequests operator to change and stabilize request amounts of the downstream.
Pull 3986: add Schedulers.reset() for better testing
Pull 3918: ReplaySubject now supports backpressure
API deprecations

Pull 3948 deprecate Completable.endWith() in favor of andThen()
Performance enhancements

Pull 3470: replay request coordination reduce overhead
Bugfixes

Pull 3924: fix RxRingBuffer-pool depending on the computation scheduler
Pull 3922: fix using() resource cleanup when factory throws or being non-eager
Pull 3941: fix Single.flatMap not composing subscription through
Pull 3958: fix just() construction to call the onCreate execution hook
Pull 3977: Use the correct Throwable to set the cause for CompositeException
Pull 4005: Fix Spsc queues reporting not empty but then poll() returns null.

**Version 1.1.5 - May 5, 2016 (Maven)**

Bugfixes

Pull 3912: fix filter() default-requesting and thus going unbounded

**1.1.4**
@stevegury stevegury released this on May 4 · 58 commits to 1.x since this release

API enhancements

Pull 3856: Provide factories for creating the default scheduler instances.
Pull 3866: Add Single.toCompletable().
Pull 3879: Expose scheduler factories which accept thread factories.
Pull 3820: Making RxPlugins reset() public
Pull 3888: New operator: onTerminateDetach - detach upstream/downstream for GC
API deprecations

Pull 3871: Deprecate remaining public scheduler types.
Performance enhancements

Pull 3761: optimize merge/flatMap for empty sources.
Pull 3864: optimize concatMapIterable/flatMapIterable.
Bugfixes

Pull 3868: Fix an unsubscribe race in EventLoopWorker.
Pull 3867: ensure waiting tasks are cancelled on worker unsubscription.
Pull 3862: fix from(Iterable) error handling of Iterable/Iterator
Pull 3886: throwIfFatal() now throws OnCompletedFailedException.
Pull 3887: Have undeliverable errors on subscribe() sent to plugin error handler.
Pull 3895: cast() should unsubscribe on crash eagerly.
Pull 3896: OperatorMapPair should unsubscribe on crash eagerly.
Pull 3890: map() and filter() should unsubscribe on crash eagerly.
Pull 3893: enable backpressure with from(Future)
Pull 3883: fix multiple chained Single.doAfterTerminate not calling actions
Pull 3904: Fix Completable swallows OnErrorNotImplementedException
Pull 3905: fix singleOrDefault() backpressure if source is empty

 **v1.1.3**
@stevegury stevegury released this on Apr 8 · 89 commits to 1.x since this release

API enhancements

Pull 3780: SyncOnSubscribe has been promoted to @Beta API.
Pull 3799: Added Completable.andThen(Single) operator
Pull 3777: Added observeOn overload to configure the prefetch/buffer size
Pull 3790: Make Single.lift public and @Experimental
Pull 3818: fromCallable promotion to @Beta
Pull 3842: improve ExecutorScheduler worker unsubscription
API deprecations

Pull 3762: Deprecate CompositeException constructor with message prefix
General enhancements

Pull 3828: AsyncSubject now supports backpressure
Pull 3829: Added rx.unsafe-disable system property to disable use of sun.misc.Unsafe even if it is available
Pull 3757: Warning: behavior change! Operator sample emits last sampled value before termination
Performance enhancements

Pull 3795: observeOn now replenishes with constant rate
Bugfixes

Pull 3809: fix merge/flatMap crash when the inner source was just(null)
Pull 3789: Prevent Single.zip() of zero Singles
Pull 3787: fix groupBy delaying group completion till all groups were emitted
Pull 3823: fix DoAfterTerminate handle if action throws
Pull 3822: make defensive copy of the properties in RxJavaPlugins
Pull 3836: fix switchMap/switchOnNext producer retention and backpressure
Pull 3840: fix concatMap scalar/empty source behavior
Pull 3839: fix takeLast() backpressure
Pull 3845: fix delaySubscription(Observable) unsubscription before triggered
# Mockito

**2.0.71-beta (2016-06-23 09:28 UTC)**

Authors: 3
Commits: 4
2: Pascal Schumacher
1: Christian Schwarz
1: Rafael Winterhalter
Improvements: 3
fix some rawtype warnings (#456)
activate VerificationWithTimeoutTest#shouldAllowTimeoutVerificationIn… (#455)
Refactored Timeout and After concurrent test (#451)

**2.0.70-beta (2016-06-21 09:16 UTC)**

Authors: 1
Commits: 1
1: ashleyfrieze
Improvements: 1
Modified JavaDoc for ArgumentMatcher (#454)

**2.0.69-beta (2016-06-19 22:57 UTC)**

Authors: 1
Commits: 6
6: Rafael Winterhalter
No notable improvements. See the commits for detailed changes.

**2.0.67-beta (2016-06-19 21:59 UTC)**

Authors: 2
Commits: 13
11: Rafael Winterhalter
2: Pascal Schumacher
Improvements: 2
javadoc: improve grammar of some sentences (#452)
speedup travis build a bit by downloading gradle-bin instead of gradl… (#371)

**2.0.65-beta (2016-06-19 19:52 UTC)**

Authors: 2
Commits: 3
2: Rafael Winterhalter
1: Alberto Scotto
Improvements: 1
BDDMockito: rename willNothing to willDoNothing (#419)

**2.0.64-beta (2016-06-19 16:54 UTC)**

Authors: 4
Commits: 17
9: Rafael Winterhalter
5: Pascal Schumacher
2: Tim van der Lippe
1: Jazzepi
Improvements: 10
update objenesis version to 2.4 (#447)
Make tests which test for timeouts with Thread#sleep more lenient. (#446)
Add PARAMETER ElementType to @Mock (#444)
downgrade assertj-core version to 1.7.1 because this version is java … (#443)
enable some ignored tests of BridgeMethodsHitAgainTest and DetectingF… (#442)
delete ignored cglib related tests (#441)
PluginStackTraceFilteringTest failing locally (#435)
Inorder timeouts (#424)
Functional interfaces for Java 8 support in Mockito 2 (#338)
Introduce functional interfaces to improve Java 8 utilisation of Mockito 2 (#337)

**2.0.62-beta (2016-06-17 12:26 UTC)**

Authors: 1
Commits: 2
2: Rafael Winterhalter
No notable improvements. See the commits for detailed changes.

**2.0.61-beta (2016-06-17 11:19 UTC)**

Authors: 3
Commits: 3
1: Andrey
1: Rafael Winterhalter
1: Tim van der Lippe
Improvements: 3
Fixed #407 Vararg method call on mock object fails (#412)
Vararg method call on mock object fails when used org.mockito.AdditionalAnswers#delegatesTo (#407)
Lazily verify without calling collector.verify() (#389)

**2.0.60-beta (2016-06-17 09:47 UTC)**

Authors: 2
Commits: 2
1: Rafael Winterhalter
1: Christian Schwarz
Improvements: 2
Fixes #426 Dropped class HandyReturnValues (#431)
Refactor instance based utility classes to static utility classes (#426)

**2.0.59-beta (2016-06-16 12:20 UTC)**

Authors: 1
Commits: 1
1: Christian Schwarz
Improvements: 1
Fixes #426 Refactored InvocationMarker to a static utility class (#432)

**2.0.58-beta (2016-06-15 23:41 UTC)**

Authors: 1
Commits: 1
1: Roi Atalla
Improvements: 1
Very tiny typo. (#434)

**2.0.57-beta (2016-06-13 22:01 UTC)**

Authors: 2
Commits: 2
1: Philipp Jardas
1: Rafael Winterhalter
Improvements: 1
Added default answer for java.util.stream.Stream (#429)

**2.0.56-beta (2016-06-13 07:26 UTC)**

Authors: 1
Commits: 1
1: lloydjm77
Improvements: 2
Fixes #312. Added documentation in OngoingStubbing.thenThrow(). (#381)
ThrowsExceptionClass is urealiable - exception doesn't containt stack trace (#312)

**2.0.55-beta (2016-06-12 23:41 UTC)**

Authors: 3
Commits: 7
4: Rafael Winterhalter
2: Christian Schwarz
1: Philipp Jardas
Improvements: 2
Refactored class Reporter to a static utillity (#427)
Mock returning java.util.Optional should return Optional.empty() by default (Java 8) (#191)

**2.0.54-beta (2016-05-27 18:52 UTC)**

Authors: 1
Commits: 1
1: Christian Schwarz
Improvements: 2
Fixes #374 Removed deprecated classes and methods (#404)
Remove deprecated API from Mockito 2 (#374)

**2.0.53-beta (2016-05-17 20:34 UTC)**

Authors: 3
Commits: 4
2: Tim van der Lippe
1: Pascal Schumacher
1: Krzysztof Wolny
Improvements: 2
Fixed method name to verifyNoMoreInteractions (#413)
correct package declaration of VerificationWithDescriptionTest (#382)

**2.0.52-beta (2016-04-23 01:33 UTC)**

Authors: 1
Commits: 3
3: Szczepan Faber
Improvements: 1
Bump JUnit to 4.12 (#400)

**2.0.51-beta (2016-04-22 12:38 UTC)**

Authors: 3
Commits: 4
2: Rafael Winterhalter
1: Vineet Kumar
1: Christian Schwarz
Improvements: 3
Remove duplication. (#377)
Fixes #365 Simplify the InvocationOnMock-API to get a casted argument (#373)
Simplify the InvocationOnMock-API to get a casted argument (#365)

**2.0.50-beta (2016-04-21 09:30 UTC)**

Authors: 1
Commits: 2
2: Rafael Winterhalter
Improvements: 1
Mocking Class that inherits from Abstract class in a different JAR doesn't override methods (#398)

**2.0.49-beta (2016-04-20 06:15 UTC)**

Authors: 1
Commits: 1
1: Rafael Winterhalter
No notable improvements. See the commits for detailed changes.

**2.0.48-beta (2016-04-18 00:52 UTC)**

Authors: 2
Commits: 18
16: Szczepan Faber
2: Roland Hauser
Improvements: 1
Fixed OSGi metadata generation (#388)

**2.0.47-beta (2016-04-16 18:10 UTC)**

Authors: 2
Commits: 9
8: david
1: Szczepan Faber
Improvements: 1
Remove deprecated code (#386)

**2.0.46-beta (2016-04-13 04:10 UTC)**

Authors: 2
Commits: 2
1: Vineet Kumar
1: Szczepan Faber
Improvements: 1
Fix typo in example in javadoc. (#376)

**2.0.45-beta (2016-04-13 03:40 UTC)**

Authors: 2
Commits: 11
8: Brice Dutheil
3: Szczepan Faber
Improvements: 1
Travis / CI improvements (#369)
# Parceler

**Release 1.1.5 (2016-05-25)**

Bug Fixes
Fixes issue with using non-local target classes' classloader

Fixes issue with checking Parcelable inheritance

**Release 1.1.4 (2016-05-16)**

Bug Fixes
Re-implemented implementation parameter

Fixed identity handling in object graphs by using list instead of map

**Release 1.1.3 (2016-05-14)**

Bug Fixes
Fixed identity handling by using IdentityCollection

Depreciations
Removed METHOD serialization strategy

Removed parcelsIndex configuration option on Parcel annotation

**Release 1.1.2 (2016-04-30)**

Bug Fixes
Fixed issue generating Parcelable classes from the output of other annotation processors

Release 1.1.1 (2016-04-11)

Bug Fixes
Fixed issue handling null associated Parcels.

Fixed classloader used with related classes.

**Release 1.1.0 (2016-04-04)**
# Roboelectric

**Robolectric 3.1**

Enhancements
Added @OnWrap and @OnUnwrap callbacks.

Added initial size to relevant collections.

Added instance identity collection during marshalling to avoid instance loops.

Significantly reduced the number of methods generated.

Deprecations
Removed NullParcelable shim from Parcels utility class for null inputs.

Bug Fixes
Fixed Enum array parceling, previously serialzied as a enum instead of an array.

Features

Support for Lollipop MR1
Support for Marshmallow
Better shadows for Play Services
Use invokedynamic for shadows and intrinsics
Upgrade Notes

See https://github.com/robolectric/robolectric/wiki/3.0-to-3.1-Upgrade-Guide
Known Issues

PowerMock does not work (#2429)
