### PR TITLE
Fix MetricsHelper.dimResToPxInt giving wrong size

### DIFF
--- a/app/src/main/java/com/xmartlabs/template/helper/ui/MetricsHelper.java
+++ b/app/src/main/java/com/xmartlabs/template/helper/ui/MetricsHelper.java
@@ -49,7 +49,7 @@ public class MetricsHelper {
    */
   @Dimension(unit = Dimension.DP)
   public static int dimResToPxInt(@DimenRes int dimenId) {
-    return dpToPxInt(getContext().getResources().getDimension(dimenId));
+    return (int) getContext().getResources().getDimension(dimenId);
   }
 
   /**


### PR DESCRIPTION
It was converting to px, but `getContext().getResources().getDimension` already returns px.
