### PR TITLE
Removes WelcomeActivity definition from the Manifest.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,11 +37,5 @@
             </intent-filter>
         </activity>
 
-        <activity
-            android:label="@string/welcome"
-            android:name=".ui.WelcomeActivity"
-            android:screenOrientation="portrait"
-            />
-
     </application>
 </manifest>


### PR DESCRIPTION
Removes the WelcomeActivity definition from the Project Manifest because that Activity no longer exists.


/cc @xmartlabs/android