### PR TITLE
Gradle wrapper update

### DIFF
--- a/bintray.gradle
+++ b/bintray.gradle
@@ -27,7 +27,7 @@ artifacts {
 def getBintrayInformation = { propertyFilePath ->
     def propertiesFile = file(propertyFilePath)
     if (!propertiesFile.exists()) {
-        logger.error("Bintray properties file not found, path=${propertiesFile.absolutePath}")
+        logger.warn("Bintray properties file not found, path=${propertiesFile.absolutePath}")
         return
     }
     def Properties properties = new Properties()

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-all.zip


### PR DESCRIPTION
Gradle wrapper update to 3.5
Prevented the build to fail if the bintray.properties is not found

/cc @xmartlabs/android
