### PR TITLE
Fixed an issue that caused errors on retrofit dagger modules

### DIFF
--- a/app/src/androidTest/java/com/xmartlabs/template/TestComponent.java
+++ b/app/src/androidTest/java/com/xmartlabs/template/TestComponent.java
@@ -5,6 +5,7 @@ import com.xmartlabs.bigbang.core.module.GsonModule;
 import com.xmartlabs.bigbang.core.module.OkHttpModule;
 import com.xmartlabs.bigbang.core.module.PicassoModule;
 import com.xmartlabs.bigbang.retrofit.module.RestServiceModule;
+import com.xmartlabs.bigbang.retrofit.module.ServiceGsonModule;
 import com.xmartlabs.template.module.ControllerModule;
 import com.xmartlabs.template.ui.common.BaseInstrumentationTest;
 
@@ -16,6 +17,7 @@ import dagger.Component;
     CoreAndroidModule.class,
     ControllerModule.class,
     GsonModule.class,
+    ServiceGsonModule.class,
     RestServiceModule.class,
     OkHttpModule.class,
     PicassoModule.class,

--- a/app/src/androidTest/java/com/xmartlabs/template/module/MockRestServiceModule.java
+++ b/app/src/androidTest/java/com/xmartlabs/template/module/MockRestServiceModule.java
@@ -9,7 +9,7 @@ import okhttp3.HttpUrl;
 
 public class MockRestServiceModule extends RestServiceModule {
   @Override
-  protected HttpUrl provideBaseUrl(Context context) {
+  public HttpUrl provideBaseUrl(Context context) {
     return HttpUrl.parse(RESTMockServer.getUrl());
   }
 }

--- a/app/src/main/java/com/xmartlabs/template/controller/SessionController.java
+++ b/app/src/main/java/com/xmartlabs/template/controller/SessionController.java
@@ -3,17 +3,23 @@ package com.xmartlabs.template.controller;
 import com.annimon.stream.Exceptional;
 import com.annimon.stream.Optional;
 import com.google.gson.Gson;
+import com.xmartlabs.bigbang.core.model.SessionType;
 import com.xmartlabs.template.model.Session;
 
 import javax.inject.Inject;
 
-public class SessionController extends com.xmartlabs.bigbang.core.controller.SessionController<Session> {
+public class SessionController extends com.xmartlabs.bigbang.core.controller.SessionController {
   @Inject
   Gson gson;
 
   @Override
-  protected Optional<Session> deserializeSession(String json) {
-    return Exceptional.of(() -> gson.fromJson(json, Session.class))
+  protected Optional<SessionType> deserializeSession(String json) {
+    return Exceptional.of(() -> (SessionType) gson.fromJson(json, Session.class))
         .getOptional();
+  }
+
+  public Optional<Session> getSession() {
+    return getAbstractSession()
+        .map(session -> (Session) session);
   }
 }

--- a/core/src/main/java/com/xmartlabs/bigbang/core/controller/SessionController.java
+++ b/core/src/main/java/com/xmartlabs/bigbang/core/controller/SessionController.java
@@ -40,10 +40,12 @@ public abstract class SessionController extends Controller {
   @CheckResult
   @NonNull
   public Optional<SessionType> getAbstractSession() {
-    return Optional.of(session).orElseGet(() -> {
-      String sessionJsonString = sharedPreferences.getString(PREFERENCES_KEY_SESSION, null);
-      return deserializeSession(sessionJsonString);
-    });
+    return session
+        .map(Optional::of)
+        .orElseGet(() -> {
+          String sessionJsonString = sharedPreferences.getString(PREFERENCES_KEY_SESSION, null);
+          return deserializeSession(sessionJsonString);
+        });
   }
 
   protected abstract Optional<SessionType> deserializeSession(String json);

--- a/core/src/main/java/com/xmartlabs/bigbang/core/controller/SessionController.java
+++ b/core/src/main/java/com/xmartlabs/bigbang/core/controller/SessionController.java
@@ -19,7 +19,7 @@ import io.reactivex.Single;
  * Thus, the {@link SessionType} object is serialized using {@link Gson}.
  * The session is retrieved once from disk and then kept in memory for faster access.
  */
-public abstract class SessionController<S extends SessionType> extends Controller {
+public abstract class SessionController extends Controller {
   private static final String PREFERENCES_KEY_SESSION = "session";
 
   @Inject
@@ -27,7 +27,7 @@ public abstract class SessionController<S extends SessionType> extends Controlle
   @Inject
   SharedPreferences sharedPreferences;
 
-  private Optional<S> session = Optional.empty();
+  private Optional<SessionType> session = Optional.empty();
 
   /**
    * Retrieves the current stored {@link SessionType}, if it exists.
@@ -39,14 +39,14 @@ public abstract class SessionController<S extends SessionType> extends Controlle
    */
   @CheckResult
   @NonNull
-  public Optional<S> getSession() {
+  public Optional<SessionType> getAbstractSession() {
     return Optional.of(session).orElseGet(() -> {
       String sessionJsonString = sharedPreferences.getString(PREFERENCES_KEY_SESSION, null);
       return deserializeSession(sessionJsonString);
     });
   }
 
-  protected abstract Optional<S> deserializeSession(String json);
+  protected abstract Optional<SessionType> deserializeSession(String json);
 
   /**
    * Stores the {@code session} into the {@link SharedPreferences}.
@@ -56,7 +56,7 @@ public abstract class SessionController<S extends SessionType> extends Controlle
    */
   @CheckResult
   @NonNull
-  public Single<S> setSession(@NonNull S session) {
+  public <S extends SessionType> Single<S> setSession(@NonNull S session) {
     return Single.fromCallable(() -> {
       String sessionJsonString = gson.toJson(session);
       boolean committed = sharedPreferences

--- a/core/src/main/java/com/xmartlabs/bigbang/core/module/PicassoModule.java
+++ b/core/src/main/java/com/xmartlabs/bigbang/core/module/PicassoModule.java
@@ -25,13 +25,13 @@ public class PicassoModule {
 
   @Provides
   @Singleton
-  Picasso providePicasso(Picasso.Builder picassoBuilder) {
+  public Picasso providePicasso(Picasso.Builder picassoBuilder) {
     return picassoBuilder.build();
   }
 
   @Provides
   @Singleton
-  Picasso.Builder providePicassoBuilder(@NonNull LoggerTree loggerTree, @NonNull Context context,
+  public Picasso.Builder providePicassoBuilder(@NonNull LoggerTree loggerTree, @NonNull Context context,
                                         @NonNull OkHttp3Downloader downloader) {
     return new Picasso.Builder(context)
         .downloader(downloader)
@@ -50,7 +50,7 @@ public class PicassoModule {
 
   @Provides
   @Singleton
-  OkHttp3Downloader provideOkHttpDownloader(@Named(OkHttpModule.CLIENT_PICASSO) OkHttpClient client) {
+  public OkHttp3Downloader provideOkHttpDownloader(@Named(OkHttpModule.CLIENT_PICASSO) OkHttpClient client) {
     return new OkHttp3Downloader(client);
   }
 }

--- a/core/src/main/java/com/xmartlabs/bigbang/core/providers/AccessTokenProvider.java
+++ b/core/src/main/java/com/xmartlabs/bigbang/core/providers/AccessTokenProvider.java
@@ -4,6 +4,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import com.annimon.stream.Optional;
+import com.xmartlabs.bigbang.core.Injector;
 import com.xmartlabs.bigbang.core.common.EntityProvider;
 import com.xmartlabs.bigbang.core.controller.SessionController;
 import com.xmartlabs.bigbang.core.model.SessionType;
@@ -18,18 +19,16 @@ import javax.inject.Inject;
 public class AccessTokenProvider implements EntityProvider<String> {
   private static final String AUTH_TOKEN_HEADER_KEY = "session";
 
-  @NonNull
-  private final SessionController<SessionType> sessionController;
-
   @Inject
-  public AccessTokenProvider(@NonNull SessionController sessionController) {
-    //noinspection unchecked
-    this.sessionController = sessionController;
+  SessionController sessionController;
+
+  public AccessTokenProvider() {
+    Injector.inject(this);
   }
 
   @Override
   public Optional<String> provideEntity() {
-    return sessionController.getSession()
+    return sessionController.getAbstractSession()
         .map(SessionType::getAccessToken)
         .flatMap(Optional::ofNullable);
   }
@@ -47,14 +46,14 @@ public class AccessTokenProvider implements EntityProvider<String> {
 
   @Override
   public void updateEntity(@Nullable String accessToken) {
-    sessionController.getSession()
+    sessionController.getAbstractSession()
         .executeIfPresent(session -> session.setAccessToken(accessToken))
         .ifPresent(sessionController::setSession);
   }
 
   @Override
   public void deleteEntity() {
-    sessionController.getSession()
+    sessionController.getAbstractSession()
         .executeIfPresent(session -> session.setAccessToken(null))
         .ifPresent(sessionController::setSession);
   }

--- a/retrofit/build.gradle
+++ b/retrofit/build.gradle
@@ -49,12 +49,14 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile project(':core')
     apt "org.projectlombok:lombok:${libraryVersion.lombok}"
+    compile "com.google.dagger:dagger:${libraryVersion.dagger}"
     compile "com.jakewharton.threetenabp:threetenabp:${libraryVersion.localDateBackport}"
     compile "com.squareup.retrofit2:converter-gson:${libraryVersion.retrofit}"
     compile "com.squareup.retrofit2:adapter-rxjava2:${libraryVersion.retrofit}"
     compile "com.squareup.retrofit2:retrofit:${libraryVersion.retrofit}"
     compile "io.reactivex.rxjava2:rxandroid:${libraryVersion.rxAndroid}"
     compile "io.reactivex.rxjava2:rxjava:${libraryVersion.rxJava}"
+    provided "com.google.dagger:dagger-compiler:${libraryVersion.dagger}"
     provided "org.projectlombok:lombok:${libraryVersion.lombok}"
     testCompile "junit:junit:${libraryVersion.junit}"
     testCompile ('org.threeten:threetenbp:1.3.2') {

--- a/retrofit/src/main/java/com/xmartlabs/bigbang/retrofit/module/RestServiceModule.java
+++ b/retrofit/src/main/java/com/xmartlabs/bigbang/retrofit/module/RestServiceModule.java
@@ -21,7 +21,7 @@ import retrofit2.converter.gson.GsonConverterFactory;
 public class RestServiceModule {
   @Provides
   @Singleton
-  Retrofit provideRetrofit(@Named(OkHttpModule.CLIENT_SERVICE) OkHttpClient client,
+  public Retrofit provideRetrofit(@Named(OkHttpModule.CLIENT_SERVICE) OkHttpClient client,
                            RxJava2CallAdapterFactory rxJavaCallAdapterFactory,
                            GsonConverterFactory gsonConverterFactory,
                            HttpUrl baseUrl,
@@ -37,25 +37,25 @@ public class RestServiceModule {
 
   @Provides
   @Singleton
-  RxJava2CallAdapterFactory provideRxJavaCallAdapterFactory() {
+  public RxJava2CallAdapterFactory provideRxJavaCallAdapterFactory() {
     return RxJava2CallAdapterFactory.create();
   }
 
   @Provides
   @Singleton
-  GsonConverterFactory provideGsonConverterFactory(@Named(ServiceGsonModule.SERVICE_GSON_NAME) Gson gson) {
+  public GsonConverterFactory provideGsonConverterFactory(@Named(ServiceGsonModule.SERVICE_GSON_NAME) Gson gson) {
     return GsonConverterFactory.create(gson);
   }
 
   @Provides
   @Singleton
-  ServiceStringConverter provideStringConverter() {
+  public ServiceStringConverter provideStringConverter() {
     return new ServiceStringConverter();
   }
 
   @Provides
   @Singleton
-  protected HttpUrl provideBaseUrl(Context context) {
+  public HttpUrl provideBaseUrl(Context context) {
     throw new UnsupportedOperationException("This method should be overridden in the app module");
   }
 }

--- a/versions.gradle
+++ b/versions.gradle
@@ -1,7 +1,7 @@
 ext {
     applicationId = "com.xmartlabs.bigbang"
-    librariesVersionCode = 31
-    librariesVersion = '0.1.31'
+    librariesVersionCode = 38
+    librariesVersion = '0.1.38'
     compileSdkVersion = 25
     minSdkVersion = 17
     targetSdkVersion = 25

--- a/versions.gradle
+++ b/versions.gradle
@@ -1,7 +1,7 @@
 ext {
     applicationId = "com.xmartlabs.bigbang"
-    librariesVersionCode = 38
-    librariesVersion = '0.1.38'
+    librariesVersionCode = 39
+    librariesVersion = '0.1.39'
     compileSdkVersion = 25
     minSdkVersion = 17
     targetSdkVersion = 25


### PR DESCRIPTION
The problem was that dagger (and more importantly it's annotation processor) was not included as a dependency in the retrofit module. Thus, when compiling it, it failed miserably.

Also, made all the provided stuff public, in case we want to override any of it.

Fixed the SessionController, removing the generic type to be able to inject it.

Changed the AccessTokenProvided to not inject itself, so to be able to extend it.

/cc @xmartlabs/android
