### PR TITLE
Updating gson

### DIFF
--- a/versions.gradle
+++ b/versions.gradle
@@ -25,7 +25,7 @@ ext {
         espresso: '2.2.2',
         firebase: '9.2.1',
         fragmentArgs: '3.0.2',
-        gson: '1.7.2',
+        gson: '2.8.0',
         jsr305: '3.0.1',
         junit: '4.12',
         localDateBackport: '1.0.4',


### PR DESCRIPTION
# Gson

## Version 2.8
_2016-10-26_  [GitHub Diff](https://github.com/google/gson/compare/gson-parent-2.7...gson-parent-2.8.0)
 * New: `TypeToken.getParameterized()` and `TypeToken.getArray()` make it easier to
   register or look up a `TypeAdapter`.
 * New: `@JsonAdapter(nullSafe=true)` to specify that a custom type adapter handles null.

## Version 2.7
_2016-06-14_  [GitHub Diff](https://github.com/google/gson/compare/gson-parent-2.6.2...gson-parent-2.7)
 * Added support for JsonSerializer/JsonDeserializer in @JsonAdapter annotation
 * Exposing Gson properties excluder(), fieldNamingStrategy(), serializeNulls(), htmlSafe()
 * Added JsonObject.size() method
 * Added JsonWriter.value(Boolean value) method
 * Using ArrayDeque, ConcurrentHashMap, and other JDK 1.6 features
 * Better error reporting
 * Plenty of other bug fixes

## Version 2.6.2
_2016-02-26_  [GitHub Diff](https://github.com/google/gson/compare/gson-parent-2.6.1...gson-parent-2.6.2)
 * Fixed an NPE bug with @JsonAdapter annotation
 * Added back OSGI manifest
 * Some documentation typo fixes

## Version 2.6.1

_2016-02-11_ [GitHub Diff](https://github.com/google/gson/compare/gson-parent-2.6...gson-parent-2.6.1)

 * Fix: The 2.6 release targeted Java 1.7, but we intend to target Java 1.6. The
   2.6.1 release is identical to 2.6, but it targets Java 1.6.


## Version 2.6

_2016-02-11_ [GitHub Diff](https://github.com/google/gson/compare/gson-parent-2.5...gson-parent-2.6)

 * Permit timezones without minutes in the default date adapter.
 * Update reader and writer for RFC 7159. This means that strings, numbers,
   booleans and null may be top-level values in JSON documents, even if the
   reader is strict.
 * New `setLenient()` method on `GsonBuilder`. This setting impacts the new
   factory method `Gson.newJsonReader()`.
 * Adapters discovered with `@JsonAdapter` are now null safe by default.


## Version 2.5

_2015-11-24_ [GitHub Diff](https://github.com/google/gson/compare/gson-parent-2.4...gson-parent-2.5)

 * Updated minimum JDK version to 1.6
 * Improved Date Deserialization by accepting many date formats
 * Added support for `java.util.Currency`, `AtomicLong`, `AtomicLongArray`, `AtomicInteger`, `AtomicIntegerArray`, `AtomicBoolean`. This change is backward-incompatible because the earlier version of Gson used the default serialization which wasn't intuitive. We hope that these classes are not used enough to actually cause problems in the field.
 * Improved debugging information when some exceptions are thrown


## Version 2.4

_2015-10-04_

 * **Drop `IOException` from `TypeAdapter.toJson()`.** This is a binary-compatible change, but may
   cause compiler errors where `IOExceptions` are being caught but no longer thrown. The correct fix
   for this problem is to remove the unnecessary `catch` clause.
 * New: `Gson.newJsonWriter` method returns configured `JsonWriter` instances.
 * New: `@SerializedName` now works with [AutoValue’s][autovalue] abstract property methods.
 * New: `@SerializedName` permits alternate names when deserializing.
 * New: `JsonWriter#jsonValue` writes raw JSON values.
 * New: APIs to add primitives directly to `JsonArray` instances.
 * New: ISO 8601 date type adapter. Find this in _extras_.
 * Fix: `FieldNamingPolicy` now works properly when running on a device with a Turkish locale.
  [autovalue]: https://github.com/google/auto/tree/master/value


## Version 2.3.1

_2014-11-20_

 * Added support to serialize objects with self-referential fields. The self-referential field is set to null in JSON. Previous version of Gson threw a StackOverflowException on encountering any self-referential fields.
   * The most visible impact of this is that Gson can now serialize Throwable (Exception and Error)
 * Added support for @JsonAdapter annotation on enums which are user defined types
 * Fixed bug in getPath() with array of objects and arrays of arrays
 * Other smaller bug fixes


## Version 2.3

_2014-08-11_

 * The new @JsonAdapter annotation to specify a Json TypeAdapter for a class field
 * JsonPath support: JsonReader.getPath() method returns the JsonPath expression
 * New public methods in JsonArray (similar to the java.util.List): `contains(JsonElement), remove(JsonElement), remove(int index), set(int index, JsonElement element)`
 * Many other smaller bug fixes


## Version 2.2.4

_2013-05-13_

 * Fix internal map (LinkedHashTreeMap) hashing bug.
 * Bug fix (Issue 511)


## Version 2.2.3

_2013-04-12_

 * Fixes for possible DoS attack due to poor String hashing


## Version 2.2.2

_2012-07-02_

 * Gson now allows a user to override default type adapters for Primitives and Strings. This behavior was allowed in earlier versions of Gson but was prohibited started Gson 2.0. We decided to allow it again: This enables a user to parse 1/0 as boolean values for compatibility with iOS JSON libraries.
 * (Incompatible behavior change in `JsonParser`): In the past, if `JsonParser` encountered a stream that terminated prematurely, it returned `JsonNull`. This behavior wasn't correct because the stream had invalid JSON, not a null. `JsonParser` is now changed to throw `JsonSyntaxException` in this case. Note that if JsonParser (or Gson) encounter an empty stream, they still return `JsonNull`.


## Version 2.2.1

_2012-05-05_

 * Very minor fixes


## Version 2.2

_2012-05-05_

 * Added getDelegateAdapter in Gson class
 * Fixed a security bug related to denial of service attack with Java HashMap String collisions.


## Version 2.1

_2011-12-30_ (Targeted Dec 31, 2011)

 * Support for user-defined streaming type adapters
 * continued performance enhancements
 * Dropped support for type hierarchy instance creators. We don't expect this to be a problem. We'll also detect fewer errors where multiple type adapters can serialize the same type. With APIs like getNextTypeAdapter, this might actually be an improvement!


## Version 2.0

_2011-11-13_

#### Faster

 * Previous versions first parsed complete document into a DOM-style model (JsonObject or JsonArray) and then bound data against that. Gson 2 does data binding directly from the stream parser.

#### More Predictable

 * Objects are serialized and deserialized in the same way, regardless of where they occur in the object graph.

#### Changes to watch out for

  * Gson 1.7 would serialize top-level nulls as "". 2.0 serializes them as "null".
    ```
    String json = gson.toJson(null, Foo.class);
    1.7: json == ""
    2.0: json == "null"
    ```

  * Gson 1.7 permitted duplicate map keys. 2.0 forbids them.
    ```
    String json = "{'a':1,'a':2}";
    Map<String, Integer> map = gson.fromJson(json, mapType);
    1.7: map == {a=2}
    2.0: JsonSyntaxException thrown
    ```

  * Gson 1.7 won’t serialize subclass fields in collection elements. 2.0 adds this extra information.
    ```
    List<Point2d> points = new ArrayList<Point2d>();
    points.add(new Point3d(1, 2, 3));
    String json = gson.toJson(points,
        new TypeToken<List<Point2d>>() {}.getType());
    1.7: json == "[{'x':1,'y':2}]"
    2.0: json == "[{'x':1,'y':2,'z':3}]"
    ```

  * Gson 1.7 binds single-element arrays as their contents. 2.0 doesn’t.
    ```
    Integer i = gson.fromJson("[42]", Integer.class);
    1.7: i == 42
    2.0: JsonSyntaxException thrown
    ```

#### Other changes to be aware of
 * Gson 2.0 doesn’t support type adapters for primitive types.
 * Gson 1.7 uses arbitrary precision for primitive type conversion (so -122.08e-2132 != 0). Gson 2.0 uses double precision (so -122.08e-2132 == 0).
 * Gson 1.7 sets subclass fields when an InstanceCreator returns a subclass when the value is a field of another object. Gson 2.0 sets fields of the requested type only.
 * Gson 1.7 versioning never skips the top-level object. Gson 2.0 versioning applies to all objects.
 * Gson 1.7 truncates oversized large integers. Gson 2.0 fails on them.
 * Gson 2.0 permits integers to have .0 fractions like "1.0".
 * Gson 1.7 throws IllegalStateException on circular references. Gson 2.0 lets the runtime throw a StackOverflowError.