### PR TITLE
Fixes the presenter injection

### DIFF
--- a/ui/src/main/java/com/xmartlabs/bigbang/ui/mvp/BaseMvpPresenter.java
+++ b/ui/src/main/java/com/xmartlabs/bigbang/ui/mvp/BaseMvpPresenter.java
@@ -21,12 +21,9 @@ import java.lang.ref.WeakReference;
 public class BaseMvpPresenter<V extends MvpView> implements MvpPresenter<V> {
   private WeakReference<V> viewReference;
 
-  public BaseMvpPresenter() {
-    Injector.inject(this);
-  }
-
   @Override
   public void attachView(V view) {
+    Injector.inject(this);
     viewReference = new WeakReference<>(view);
   }
 


### PR DESCRIPTION
The presenter is a generic class and thus it cannot be injected.
For that reason, the injection must happen in another place.

/cc @xmartlabs/android
