### PR TITLE
Service improvements

### DIFF
--- a/retrofit/src/main/java/com/xmartlabs/bigbang/retrofit/controller/ServiceController.java
+++ b/retrofit/src/main/java/com/xmartlabs/bigbang/retrofit/controller/ServiceController.java
@@ -22,7 +22,7 @@ import io.reactivex.SingleTransformer;
  * @param <Id> Type of the entity id
  * @param <E> Entity of the controller
  */
-public class ServiceController<Id, E extends EntityWithId<Id>> extends Controller
+public abstract class ServiceController<Id, E extends EntityWithId<Id>> extends Controller
     implements EntityServiceProvider<Id, E> {
   @CheckResult
   @NonNull

--- a/retrofit/src/main/java/com/xmartlabs/bigbang/retrofit/module/RestServiceModule.java
+++ b/retrofit/src/main/java/com/xmartlabs/bigbang/retrofit/module/RestServiceModule.java
@@ -13,6 +13,7 @@ import dagger.Module;
 import dagger.Provides;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
+import retrofit2.Converter;
 import retrofit2.Retrofit;
 import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory;
 import retrofit2.converter.gson.GsonConverterFactory;
@@ -25,11 +26,11 @@ public class RestServiceModule {
                            RxJava2CallAdapterFactory rxJavaCallAdapterFactory,
                            GsonConverterFactory gsonConverterFactory,
                            HttpUrl baseUrl,
-                           ServiceStringConverter serviceStringConverter) {
+                           Converter.Factory stringConverter) {
     return new Retrofit.Builder()
         .addCallAdapterFactory(rxJavaCallAdapterFactory)
         .addConverterFactory(gsonConverterFactory)
-        .addConverterFactory(serviceStringConverter)
+        .addConverterFactory(stringConverter)
         .baseUrl(baseUrl)
         .client(client)
         .build();
@@ -49,7 +50,7 @@ public class RestServiceModule {
 
   @Provides
   @Singleton
-  public ServiceStringConverter provideStringConverter() {
+  public Converter.Factory provideStringConverter() {
     return new ServiceStringConverter();
   }
 


### PR DESCRIPTION
ServiceController is now abstract as this class should not be instantiated.
Also, the provideRetrofit method in RestServiceModule was modified to receive a Converter.Factory. Before this change, it received a ServiceStringConverter which restricted you to use the existing implementation or to override it. You can now use the converter you wish, as long as it is of the Converter.Factory type.

/cc @xmartlabs/android
