### PR TITLE
Added setItems for multiple item types in BaseRecyclerViewAdapter

### DIFF
--- a/ui/src/main/java/com/xmartlabs/bigbang/ui/common/recyclerview/BaseRecyclerViewAdapter.java
+++ b/ui/src/main/java/com/xmartlabs/bigbang/ui/common/recyclerview/BaseRecyclerViewAdapter.java
@@ -286,7 +286,7 @@ public abstract class BaseRecyclerViewAdapter extends RecyclerView.Adapter<Recyc
         //noinspection unchecked
         return Exceptional.of(() -> areItemsTheSameFunction.apply(
             (T) items.get(oldItemPosition).getItem(),
-            (T) newItems.get(newItemPosition)))
+            newItems.get(newItemPosition)))
             .ifException(Timber::w)
             .getOrElse(false);
       }
@@ -296,7 +296,7 @@ public abstract class BaseRecyclerViewAdapter extends RecyclerView.Adapter<Recyc
         //noinspection unchecked
         return Exceptional.of(() -> areContentTheSameFunction.apply(
             (T) items.get(oldItemPosition).getItem(),
-             newItems.get(newItemPosition)))
+            newItems.get(newItemPosition)))
             .ifException(Timber::w)
             .getOrElse(false);
       }

--- a/ui/src/main/java/com/xmartlabs/bigbang/ui/common/recyclerview/BaseRecyclerViewAdapter.java
+++ b/ui/src/main/java/com/xmartlabs/bigbang/ui/common/recyclerview/BaseRecyclerViewAdapter.java
@@ -236,7 +236,7 @@ public abstract class BaseRecyclerViewAdapter extends RecyclerView.Adapter<Recyc
    * @param areItemsTheSameFunction   A function which checks that two items are the same.
    * @param areContentTheSameFunction A function which checks that the content of two items are the same.
    */
-  protected <T extends RecycleItemType> void setMultipleTypeItems(final @Nullable List<Pair<?,T>> newItems,
+  protected <T extends RecycleItemType> void setMultipleTypeItems(final @Nullable List<Pair<T,?>> newItems,
                                                       @NonNull BiFunction<Object, Object, Boolean> areItemsTheSameFunction,
                                                       @NonNull BiFunction<Object, Object, Boolean> areContentTheSameFunction) {
     if (CollectionHelper.isNullOrEmpty(newItems)) {

--- a/ui/src/main/java/com/xmartlabs/bigbang/ui/common/recyclerview/BaseRecyclerViewAdapter.java
+++ b/ui/src/main/java/com/xmartlabs/bigbang/ui/common/recyclerview/BaseRecyclerViewAdapter.java
@@ -236,7 +236,7 @@ public abstract class BaseRecyclerViewAdapter extends RecyclerView.Adapter<Recyc
    * @param areItemsTheSameFunction   A function which checks that two items are the same.
    * @param areContentTheSameFunction A function which checks that the content of two items are the same.
    */
-  protected <T extends RecycleItemType> void setMultipleTypeItems(final @Nullable List<Pair<T,?>> newItems,
+  protected void setMultipleTypeItems(final @Nullable List<Pair<? extends RecycleItemType,?>> newItems,
                                                       @NonNull BiFunction<Object, Object, Boolean> areItemsTheSameFunction,
                                                       @NonNull BiFunction<Object, Object, Boolean> areContentTheSameFunction) {
     if (CollectionHelper.isNullOrEmpty(newItems)) {
@@ -253,7 +253,7 @@ public abstract class BaseRecyclerViewAdapter extends RecyclerView.Adapter<Recyc
         .subscribe(diffResult -> {
           items.clear();
           Stream.of(newItems)
-              .forEach(pair -> addItemWithoutNotifying(pair.second, pair.first, true));
+              .forEach(pair -> addItemWithoutNotifying(pair.first, pair.second, true));
           diffResult.dispatchUpdatesTo(this);
         });
   }

--- a/ui/src/main/java/com/xmartlabs/bigbang/ui/common/recyclerview/BaseRecyclerViewAdapter.java
+++ b/ui/src/main/java/com/xmartlabs/bigbang/ui/common/recyclerview/BaseRecyclerViewAdapter.java
@@ -5,6 +5,7 @@ import android.support.annotation.LayoutRes;
 import android.support.annotation.MainThread;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.v4.util.Pair;
 import android.support.v7.util.DiffUtil;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
@@ -14,7 +15,6 @@ import android.view.ViewGroup;
 import com.annimon.stream.IntPair;
 import com.annimon.stream.Objects;
 import com.annimon.stream.Stream;
-import com.annimon.stream.function.Predicate;
 import com.xmartlabs.bigbang.core.helper.CollectionHelper;
 import com.xmartlabs.bigbang.core.helper.ObjectHelper;
 import com.xmartlabs.bigbang.core.helper.function.BiFunction;
@@ -223,6 +223,37 @@ public abstract class BaseRecyclerViewAdapter extends RecyclerView.Adapter<Recyc
           Stream.of(newItems)
               .forEach(item -> addItemWithoutNotifying(type, item, false));
           addItemTypeIfNeeded(type);
+          diffResult.dispatchUpdatesTo(this);
+        });
+  }
+
+  /**
+   * Sets the items data for the recycler view and notifying any registered observers that the data set has
+   * changed. It uses a function that calculates the difference between the old and the new items
+   * in order to improve the update process.
+   *
+   * @param newItems                  Items to be added. Each Pair consists of an item and its RecycleItemType.
+   * @param areItemsTheSameFunction   A function which checks that two items are the same.
+   * @param areContentTheSameFunction A function which checks that the content of two items are the same.
+   */
+  protected <T extends RecycleItemType> void setMultipleTypeItems(final @Nullable List<Pair<?,T>> newItems,
+                                                      @NonNull BiFunction<Object, Object, Boolean> areItemsTheSameFunction,
+                                                      @NonNull BiFunction<Object, Object, Boolean> areContentTheSameFunction) {
+    if (CollectionHelper.isNullOrEmpty(newItems)) {
+      return;
+    }
+
+    if (updateElementsDisposable != null && !updateElementsDisposable.isDisposed()) {
+      updateElementsDisposable.dispose();
+    }
+    updateElementsDisposable = Single.fromCallable(() -> DiffUtil
+        .calculateDiff(getUpdateDiffCallback(newItems, areItemsTheSameFunction, areContentTheSameFunction)))
+        .subscribeOn(Schedulers.io())
+        .observeOn(AndroidSchedulers.mainThread())
+        .subscribe(diffResult -> {
+          items.clear();
+          Stream.of(newItems)
+              .forEach(pair -> addItemWithoutNotifying(pair.second, pair.first, true));
           diffResult.dispatchUpdatesTo(this);
         });
   }

--- a/ui/src/main/java/com/xmartlabs/bigbang/ui/common/recyclerview/BaseRecyclerViewAdapter.java
+++ b/ui/src/main/java/com/xmartlabs/bigbang/ui/common/recyclerview/BaseRecyclerViewAdapter.java
@@ -206,9 +206,9 @@ public abstract class BaseRecyclerViewAdapter extends RecyclerView.Adapter<Recyc
    * @param areContentTheSameFunction A function which checks that the content of two items are the same.
    */
   @SuppressWarnings("WeakerAccess")
-  protected <T extends RecycleItemType> void setItems(@NonNull T type, final @Nullable List<?> newItems,
-                                                      @NonNull BiFunction<Object, Object, Boolean> areItemsTheSameFunction,
-                                                      @NonNull BiFunction<Object, Object, Boolean> areContentTheSameFunction) {
+  protected <T, R extends RecycleItemType> void setItems(@NonNull R type, final @Nullable List<T> newItems,
+                                                      @NonNull BiFunction<T, T, Boolean> areItemsTheSameFunction,
+                                                      @NonNull BiFunction<T, T, Boolean> areContentTheSameFunction) {
     if (CollectionHelper.isNullOrEmpty(newItems)) {
       return;
     }

--- a/ui/src/main/java/com/xmartlabs/bigbang/ui/common/recyclerview/BaseRecyclerViewAdapter.java
+++ b/ui/src/main/java/com/xmartlabs/bigbang/ui/common/recyclerview/BaseRecyclerViewAdapter.java
@@ -207,8 +207,8 @@ public abstract class BaseRecyclerViewAdapter extends RecyclerView.Adapter<Recyc
    */
   @SuppressWarnings("WeakerAccess")
   protected <T, R extends RecycleItemType> void setItems(@NonNull R type, final @Nullable List<T> newItems,
-                                                      @NonNull BiFunction<T, T, Boolean> areItemsTheSameFunction,
-                                                      @NonNull BiFunction<T, T, Boolean> areContentTheSameFunction) {
+                                                         @NonNull BiFunction<T, T, Boolean> areItemsTheSameFunction,
+                                                         @NonNull BiFunction<T, T, Boolean> areContentTheSameFunction) {
     if (CollectionHelper.isNullOrEmpty(newItems)) {
       return;
     }
@@ -240,8 +240,8 @@ public abstract class BaseRecyclerViewAdapter extends RecyclerView.Adapter<Recyc
    * @param areContentTheSameFunction A function which checks that the content of two items are the same.
    */
   protected <T> void setMultipleTypeItems(final @Nullable List<Pair<? extends RecycleItemType,T>> newItems,
-                                                      @NonNull BiFunction<T, T, Boolean> areItemsTheSameFunction,
-                                                      @NonNull BiFunction<T, T, Boolean> areContentTheSameFunction) {
+                                          @NonNull BiFunction<T, T, Boolean> areItemsTheSameFunction,
+                                          @NonNull BiFunction<T, T, Boolean> areContentTheSameFunction) {
     if (CollectionHelper.isNullOrEmpty(newItems)) {
       return;
     }

--- a/ui/src/main/java/com/xmartlabs/bigbang/ui/common/recyclerview/SingleItemBaseRecyclerViewAdapter.java
+++ b/ui/src/main/java/com/xmartlabs/bigbang/ui/common/recyclerview/SingleItemBaseRecyclerViewAdapter.java
@@ -81,9 +81,9 @@ public abstract class SingleItemBaseRecyclerViewAdapter<T, VH extends RecyclerVi
    * @param areItemsTheSameFunction   A function which checks that two items are the same.
    * @param areContentTheSameFunction A function which checks that the content of two items are the same.
    */
-  protected void setItems(final @Nullable List<?> newItems,
-                          @NonNull BiFunction<Object, Object, Boolean> areItemsTheSameFunction,
-                          @NonNull BiFunction<Object, Object, Boolean> areContentTheSameFunction) {
+  protected void setItems(final @Nullable List<T> newItems,
+                          @NonNull BiFunction<T, T, Boolean> areItemsTheSameFunction,
+                          @NonNull BiFunction<T, T, Boolean> areContentTheSameFunction) {
     setItems(this, newItems, areItemsTheSameFunction, areContentTheSameFunction);
   }
 


### PR DESCRIPTION
Added a `setMultipleTypeItems` method to the `BaseRecyclerViewAdapter` class. This method allows you to set items of multiple ViewHolder types, all in one operation (before you couldn't do this because it would have meant calling `setItems` as many times as types you had, and as each `setItem` call cleared the items, it wasn't possible to do it).

/cc @xmartlabs/android