### PR TITLE
Fix setItems (added clearAll call if newItems are empty or null)

### DIFF
--- a/ui/src/main/java/com/xmartlabs/bigbang/ui/common/recyclerview/BaseRecyclerViewAdapter.java
+++ b/ui/src/main/java/com/xmartlabs/bigbang/ui/common/recyclerview/BaseRecyclerViewAdapter.java
@@ -210,6 +210,7 @@ public abstract class BaseRecyclerViewAdapter extends RecyclerView.Adapter<Recyc
                                                          @NonNull BiFunction<T, T, Boolean> areItemsTheSameFunction,
                                                          @NonNull BiFunction<T, T, Boolean> areContentTheSameFunction) {
     if (CollectionHelper.isNullOrEmpty(newItems)) {
+      clearAll();
       return;
     }
 
@@ -243,6 +244,7 @@ public abstract class BaseRecyclerViewAdapter extends RecyclerView.Adapter<Recyc
                                           @NonNull BiFunction<T, T, Boolean> areItemsTheSameFunction,
                                           @NonNull BiFunction<T, T, Boolean> areContentTheSameFunction) {
     if (CollectionHelper.isNullOrEmpty(newItems)) {
+      clearAll();
       return;
     }
 


### PR DESCRIPTION
Added call to clearAll in that situation. This is because a bug was discovered in the kotlin branch by @michaelEllisUy and it also affects this one.

/cc @xmartlabs/android