### PR TITLE
Adds new IO Transformers

### DIFF
--- a/core/src/main/java/com/xmartlabs/bigbang/core/controller/Controller.java
+++ b/core/src/main/java/com/xmartlabs/bigbang/core/controller/Controller.java
@@ -4,7 +4,7 @@ import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
 
 import com.xmartlabs.bigbang.core.Injector;
-import com.xmartlabs.bigbang.core.helper.IoSchedulersTransformationHelper;
+import com.xmartlabs.bigbang.core.helper.SchedulersTransformationHelper;
 import com.xmartlabs.bigbang.core.helper.RxTransformerHelper;
 
 import io.reactivex.Completable;
@@ -17,6 +17,7 @@ import io.reactivex.Observable;
 import io.reactivex.ObservableTransformer;
 import io.reactivex.Single;
 import io.reactivex.SingleTransformer;
+import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.schedulers.Schedulers;
 
 /**
@@ -28,10 +29,86 @@ public abstract class Controller {
     Injector.inject(this);
   }
 
+
+  /**
+   * @deprecated The transformer shouldn't observe on the {Android main thread. You should be the one
+   * to decide when to observe on the main thread. Instead of this, use
+   * {@link RxTransformerHelper#completableIoTransformer} (it subscribes and observes on Io bound {@link Schedulers})
+   *
+   * CompletableTransformer that subscribes the stream in the Io {@link Schedulers} and observes
+   * it on the {Android main thread.
+   *
+   */
+  @Deprecated
+  @NonNull
+  public static final CompletableTransformer completableIoAndMainThreadTransformer = upstream -> upstream
+      .subscribeOn(Schedulers.io())
+      .observeOn(AndroidSchedulers.mainThread());
+
+  /**
+   * @deprecated The transformer shouldn't observe on the {Android main thread. You should be the one
+   * to decide when to observe on the main thread. Instead of this, use
+   * {@link RxTransformerHelper#flowableIoTransformer} (it subscribes and observes on Io bound {@link Schedulers})
+   *
+   * SingleTransformer that subscribes the stream in the Io {@link Schedulers} and observes
+   * it on the {Android main thread.
+   *
+   */
+  @Deprecated
+  @NonNull
+  public static final FlowableTransformer flowableIoAndMainThreadTransformer = upstream -> upstream
+      .subscribeOn(Schedulers.io())
+      .observeOn(AndroidSchedulers.mainThread());
+
+  /**
+   * @deprecated The transformer shouldn't observe on the {Android main thread. You should be the one
+   * to decide when to observe on the main thread. Instead of this, use
+   * {@link RxTransformerHelper#maybeIoTransformer} (it subscribes and observes on Io bound {@link Schedulers})
+   *
+   * SingleTransformer that subscribes the stream in the Io {@link Schedulers} and observes
+   * it on the {Android main thread.
+   *
+   */
+  @Deprecated
+  @NonNull
+  public static final MaybeTransformer maybeIoAndMainThreadTransformer = upstream -> upstream
+      .subscribeOn(Schedulers.io())
+      .observeOn(AndroidSchedulers.mainThread());
+
+  /**
+   * @deprecated The transformer shouldn't observe on the {Android main thread. You should be the one
+   * to decide when to observe on the main thread. Instead of this, use
+   * {@link RxTransformerHelper#observableIoTransformer} (it subscribes and observes on Io bound {@link Schedulers})
+   *
+   * SingleTransformer that subscribes the stream in the Io {@link Schedulers} and observes
+   * it on the {Android main thread.
+   *
+   */
+  @Deprecated
+  @NonNull
+  public static final ObservableTransformer observableIoAndMainThreadTransformer = observable -> observable
+      .subscribeOn(Schedulers.io())
+      .observeOn(AndroidSchedulers.mainThread());
+
+  /**
+   * @deprecated The transformer shouldn't observe on the {Android main thread. You should be the one
+   * to decide when to observe on the main thread. Instead of this, use
+   * {@link RxTransformerHelper#singleIoTransformer} (it subscribes and observes on Io bound {@link Schedulers})
+   *
+   * SingleTransformer that subscribes the stream in the Io {@link Schedulers} and observes
+   * it on the {Android main thread.
+   *
+   */
+  @Deprecated
+  @NonNull
+  public static final SingleTransformer singleIoAndMainThreadTransformer = upstream -> upstream
+      .subscribeOn(Schedulers.io())
+      .observeOn(AndroidSchedulers.mainThread());
+
   /**
    * @deprecated The transformation shouldn't observe on the {Android main thread. You should be the one
    * to decide when to observe on the main thread. Instead of this, use
-   * {@link IoSchedulersTransformationHelper#applyCompletableIoSchedulersTransformation()}
+   * {@link SchedulersTransformationHelper#applyCompletableIoSchedulersTransformation()}
    * (it subscribes and observes on Io bound {@link Schedulers})
    *
    * Provides the Io schedule {@link Completable} transformation.
@@ -43,13 +120,13 @@ public abstract class Controller {
   @Deprecated
   @NonNull
   protected CompletableTransformer applyCompletableIoSchedulers() {
-    return RxTransformerHelper.completableIoAndMainThreadTransformer;
+    return completableIoAndMainThreadTransformer;
   }
 
   /**
    * @deprecated The transformation shouldn't observe on the {Android main thread. You should be the one
    * to decide when to observe on the main thread. Instead of this, use
-   * {@link IoSchedulersTransformationHelper#applyFlowableIoSchedulersTransformation()}
+   * {@link SchedulersTransformationHelper#applyFlowableIoSchedulersTransformation()}
    * (it subscribes and observes on Io bound {@link Schedulers})
    *
    * Provides the Io schedule {@link Observable} transformation.
@@ -62,13 +139,13 @@ public abstract class Controller {
   @NonNull
   protected <T> FlowableTransformer<T, T> applyFlowableIoSchedulers() {
     //noinspection unchecked
-    return (FlowableTransformer<T, T>) RxTransformerHelper.flowableIoAndMainThreadTransformer;
+    return (FlowableTransformer<T, T>) flowableIoAndMainThreadTransformer;
   }
 
   /**
    * @deprecated The transformation shouldn't observe on the {Android main thread. You should be the one
    * to decide when to observe on the main thread. Instead of this, use
-   * {@link IoSchedulersTransformationHelper#applySingleIoSchedulersTransformation()}
+   * {@link SchedulersTransformationHelper#applySingleIoSchedulersTransformation()}
    * (it subscribes and observes on Io bound {@link Schedulers})
    *
    * Provides the Io schedule {@link Maybe} transformation.
@@ -81,13 +158,13 @@ public abstract class Controller {
   @NonNull
   protected <T> MaybeTransformer<T, T> applyMaybeIoSchedulers() {
     //noinspection unchecked
-    return (MaybeTransformer<T, T>) RxTransformerHelper.maybeIoAndMainThreadTransformer;
+    return (MaybeTransformer<T, T>) maybeIoAndMainThreadTransformer;
   }
 
   /**
    * @deprecated The transformation shouldn't observe on the {Android main thread. You should be the one
    * to decide when to observe on the main thread. Instead of this, use
-   * {@link IoSchedulersTransformationHelper#applySingleIoSchedulersTransformation()}
+   * {@link SchedulersTransformationHelper#applySingleIoSchedulersTransformation()}
    * (it subscribes and observes on Io bound {@link Schedulers})
    *
    * Provides the Io schedule {@link Observable} transformation.
@@ -100,13 +177,13 @@ public abstract class Controller {
   @NonNull
   protected <T> ObservableTransformer<T, T> applyObservableIoSchedulers() {
     //noinspection unchecked
-    return (ObservableTransformer<T, T>) RxTransformerHelper.observableIoAndMainThreadTransformer;
+    return (ObservableTransformer<T, T>) observableIoAndMainThreadTransformer;
   }
 
   /**
    * @deprecated The transformation shouldn't observe on the {Android main thread. You should be the one
    * to decide when to observe on the main thread. Instead of this, use
-   * {@link IoSchedulersTransformationHelper#applySingleIoSchedulersTransformation()}
+   * {@link SchedulersTransformationHelper#applySingleIoSchedulersTransformation()}
    * (it subscribes and observes on Io bound {@link Schedulers})
    *
    * Provides the Io schedule {@link Single} transformation.
@@ -119,6 +196,6 @@ public abstract class Controller {
   @NonNull
   protected <T> SingleTransformer<T, T> applySingleIoSchedulers() {
     //noinspection unchecked
-    return (SingleTransformer<T, T>) RxTransformerHelper.singleIoAndMainThreadTransformer;
+    return (SingleTransformer<T, T>) singleIoAndMainThreadTransformer;
   }
 }

--- a/core/src/main/java/com/xmartlabs/bigbang/core/controller/Controller.java
+++ b/core/src/main/java/com/xmartlabs/bigbang/core/controller/Controller.java
@@ -4,6 +4,7 @@ import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
 
 import com.xmartlabs.bigbang.core.Injector;
+import com.xmartlabs.bigbang.core.helper.IoSchedulersTransformationHelper;
 import com.xmartlabs.bigbang.core.helper.RxTransformerHelper;
 
 import io.reactivex.Completable;
@@ -28,73 +29,10 @@ public abstract class Controller {
   }
 
   /**
-   * Provides the Io schedule {@link Single} transformation.
-   * Subscribes and observes the stream in the Io {@link Schedulers}.
-   *
-   * @return The stream with the schedule transformation
-   */
-  @CheckResult
-  @NonNull
-  protected CompletableTransformer applyCompletableIoSchedulersTransformation() {
-    return RxTransformerHelper.completableIoTransformer;
-  }
-
-  /**
-   * Provides the Io schedule {@link Single} transformation.
-   * Subscribes and observes the stream in the Io {@link Schedulers}.
-   *
-   * @return The stream with the schedule transformation
-   */
-  @CheckResult
-  @NonNull
-  protected <T> FlowableTransformer<T, T> applyFlowableIoSchedulersTransformation() {
-    //noinspection unchecked
-    return (FlowableTransformer<T, T>) RxTransformerHelper.flowableIoTransformer;
-  }
-
-  /**
-   * Provides the Io schedule {@link Single} transformation.
-   * Subscribes and observes the stream in the Io {@link Schedulers}.
-   *
-   * @return The stream with the schedule transformation
-   */
-  @CheckResult
-  @NonNull
-  protected <T> MaybeTransformer<T, T> applyMaybeIoSchedulersTransformation() {
-    //noinspection unchecked
-    return (MaybeTransformer<T, T>) RxTransformerHelper.maybeIoTransformer;
-  }
-
-  /**
-   * Provides the Io schedule {@link Single} transformation.
-   * Subscribes and observes the stream in the Io {@link Schedulers}.
-   *
-   * @return The stream with the schedule transformation
-   */
-  @CheckResult
-  @NonNull
-  protected <T> ObservableTransformer<T, T> applyObservableIoSchedulersTransformation() {
-    //noinspection unchecked
-    return (ObservableTransformer<T, T>) RxTransformerHelper.observableIoTransformer;
-  }
-
-  /**
-   * Provides the Io schedule {@link Single} transformation.
-   * Subscribes and observes the stream on Io bound {@link Schedulers}.
-   *
-   * @return The stream with the schedule transformation
-   */
-  @CheckResult
-  @NonNull
-  protected <T> SingleTransformer<T, T> applySingleIoSchedulersTransformation() {
-    //noinspection unchecked
-    return (SingleTransformer<T, T>) RxTransformerHelper.singleIoTransformer;
-  }
-
-  /**
    * @deprecated The transformation shouldn't observe on the {Android main thread. You should be the one
    * to decide when to observe on the main thread. Instead of this, use
-   * {@link #applySingleIoSchedulersTransformation()} (it subscribes and observes on Io bound {@link Schedulers})
+   * {@link IoSchedulersTransformationHelper#applyCompletableIoSchedulersTransformation()}
+   * (it subscribes and observes on Io bound {@link Schedulers})
    *
    * Provides the Io schedule {@link Completable} transformation.
    * Subscribes the stream to Io bound {@link Schedulers} and observes it in the {Android main thread.
@@ -111,7 +49,8 @@ public abstract class Controller {
   /**
    * @deprecated The transformation shouldn't observe on the {Android main thread. You should be the one
    * to decide when to observe on the main thread. Instead of this, use
-   * {@link #applySingleIoSchedulersTransformation()} (it subscribes and observes on Io bound {@link Schedulers})
+   * {@link IoSchedulersTransformationHelper#applyFlowableIoSchedulersTransformation()}
+   * (it subscribes and observes on Io bound {@link Schedulers})
    *
    * Provides the Io schedule {@link Observable} transformation.
    * Subscribes the stream to Io bound {@link Flowable} and observes it in the {Android main thread.
@@ -129,7 +68,8 @@ public abstract class Controller {
   /**
    * @deprecated The transformation shouldn't observe on the {Android main thread. You should be the one
    * to decide when to observe on the main thread. Instead of this, use
-   * {@link #applySingleIoSchedulersTransformation()} (it subscribes and observes on Io bound {@link Schedulers})
+   * {@link IoSchedulersTransformationHelper#applySingleIoSchedulersTransformation()}
+   * (it subscribes and observes on Io bound {@link Schedulers})
    *
    * Provides the Io schedule {@link Maybe} transformation.
    * Subscribes the stream to Io bound {@link Schedulers} and observes it in the {Android main thread.
@@ -147,7 +87,8 @@ public abstract class Controller {
   /**
    * @deprecated The transformation shouldn't observe on the {Android main thread. You should be the one
    * to decide when to observe on the main thread. Instead of this, use
-   * {@link #applySingleIoSchedulersTransformation()} (it subscribes and observes on Io bound {@link Schedulers})
+   * {@link IoSchedulersTransformationHelper#applySingleIoSchedulersTransformation()}
+   * (it subscribes and observes on Io bound {@link Schedulers})
    *
    * Provides the Io schedule {@link Observable} transformation.
    * Subscribes the stream to Io bound {@link Schedulers} and observes it in the {Android main thread.
@@ -165,7 +106,8 @@ public abstract class Controller {
   /**
    * @deprecated The transformation shouldn't observe on the {Android main thread. You should be the one
    * to decide when to observe on the main thread. Instead of this, use
-   * {@link #applySingleIoSchedulersTransformation()} (it subscribes and observes on Io bound {@link Schedulers})
+   * {@link IoSchedulersTransformationHelper#applySingleIoSchedulersTransformation()}
+   * (it subscribes and observes on Io bound {@link Schedulers})
    *
    * Provides the Io schedule {@link Single} transformation.
    * Subscribes the stream to Io bound {@link Schedulers} and observes it in the {Android main thread.

--- a/core/src/main/java/com/xmartlabs/bigbang/core/controller/Controller.java
+++ b/core/src/main/java/com/xmartlabs/bigbang/core/controller/Controller.java
@@ -29,7 +29,7 @@ public abstract class Controller {
 
   /**
    * Provides the Io schedule {@link Single} transformation.
-   * Subscribes the stream to Io bound {@link Schedulers} and observes it in the {Android main thread.
+   * Subscribes and observes the stream in the Io {@link Schedulers}.
    *
    * @return The stream with the schedule transformation
    */
@@ -41,7 +41,7 @@ public abstract class Controller {
 
   /**
    * Provides the Io schedule {@link Single} transformation.
-   * Subscribes the stream to Io bound {@link Schedulers} and observes it in the {Android main thread.
+   * Subscribes and observes the stream in the Io {@link Schedulers}.
    *
    * @return The stream with the schedule transformation
    */
@@ -54,7 +54,7 @@ public abstract class Controller {
 
   /**
    * Provides the Io schedule {@link Single} transformation.
-   * Subscribes the stream to Io bound {@link Schedulers} and observes it in the {Android main thread.
+   * Subscribes and observes the stream in the Io {@link Schedulers}.
    *
    * @return The stream with the schedule transformation
    */
@@ -67,7 +67,7 @@ public abstract class Controller {
 
   /**
    * Provides the Io schedule {@link Single} transformation.
-   * Subscribes the stream to Io bound {@link Schedulers} and observes it in the {Android main thread.
+   * Subscribes and observes the stream in the Io {@link Schedulers}.
    *
    * @return The stream with the schedule transformation
    */
@@ -80,7 +80,7 @@ public abstract class Controller {
 
   /**
    * Provides the Io schedule {@link Single} transformation.
-   * Subscribes the stream to Io bound {@link Schedulers} and observes it in the {Android main thread.
+   * Subscribes and observes the stream on Io bound {@link Schedulers}.
    *
    * @return The stream with the schedule transformation
    */
@@ -92,7 +92,9 @@ public abstract class Controller {
   }
 
   /**
-   * @deprecated
+   * @deprecated The transformation shouldn't observe on the {Android main thread. You should be the one
+   * to decide when to observe on the main thread. Instead of this, use
+   * {@link #applySingleIoSchedulersTransformation()} (it subscribes and observes on Io bound {@link Schedulers})
    *
    * Provides the Io schedule {@link Completable} transformation.
    * Subscribes the stream to Io bound {@link Schedulers} and observes it in the {Android main thread.
@@ -107,7 +109,9 @@ public abstract class Controller {
   }
 
   /**
-   * @deprecated
+   * @deprecated The transformation shouldn't observe on the {Android main thread. You should be the one
+   * to decide when to observe on the main thread. Instead of this, use
+   * {@link #applySingleIoSchedulersTransformation()} (it subscribes and observes on Io bound {@link Schedulers})
    *
    * Provides the Io schedule {@link Observable} transformation.
    * Subscribes the stream to Io bound {@link Flowable} and observes it in the {Android main thread.
@@ -123,7 +127,9 @@ public abstract class Controller {
   }
 
   /**
-   * @deprecated
+   * @deprecated The transformation shouldn't observe on the {Android main thread. You should be the one
+   * to decide when to observe on the main thread. Instead of this, use
+   * {@link #applySingleIoSchedulersTransformation()} (it subscribes and observes on Io bound {@link Schedulers})
    *
    * Provides the Io schedule {@link Maybe} transformation.
    * Subscribes the stream to Io bound {@link Schedulers} and observes it in the {Android main thread.
@@ -139,7 +145,9 @@ public abstract class Controller {
   }
 
   /**
-   * @deprecated
+   * @deprecated The transformation shouldn't observe on the {Android main thread. You should be the one
+   * to decide when to observe on the main thread. Instead of this, use
+   * {@link #applySingleIoSchedulersTransformation()} (it subscribes and observes on Io bound {@link Schedulers})
    *
    * Provides the Io schedule {@link Observable} transformation.
    * Subscribes the stream to Io bound {@link Schedulers} and observes it in the {Android main thread.
@@ -155,7 +163,9 @@ public abstract class Controller {
   }
 
   /**
-   * @deprecated
+   * @deprecated The transformation shouldn't observe on the {Android main thread. You should be the one
+   * to decide when to observe on the main thread. Instead of this, use
+   * {@link #applySingleIoSchedulersTransformation()} (it subscribes and observes on Io bound {@link Schedulers})
    *
    * Provides the Io schedule {@link Single} transformation.
    * Subscribes the stream to Io bound {@link Schedulers} and observes it in the {Android main thread.

--- a/core/src/main/java/com/xmartlabs/bigbang/core/controller/Controller.java
+++ b/core/src/main/java/com/xmartlabs/bigbang/core/controller/Controller.java
@@ -4,6 +4,7 @@ import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
 
 import com.xmartlabs.bigbang.core.Injector;
+import com.xmartlabs.bigbang.core.helper.RxTransformerHelper;
 
 import io.reactivex.Completable;
 import io.reactivex.CompletableTransformer;
@@ -15,7 +16,6 @@ import io.reactivex.Observable;
 import io.reactivex.ObservableTransformer;
 import io.reactivex.Single;
 import io.reactivex.SingleTransformer;
-import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.schedulers.Schedulers;
 
 /**
@@ -23,80 +23,8 @@ import io.reactivex.schedulers.Schedulers;
  * It automatically injects inherited classes.
  */
 public abstract class Controller {
-  @NonNull
-  private final CompletableTransformer completableIoTransformer = upstream -> upstream
-      .subscribeOn(Schedulers.io())
-      .observeOn(AndroidSchedulers.mainThread());
-  @NonNull
-  private final FlowableTransformer flowableIoTransformer = upstream -> upstream
-      .subscribeOn(Schedulers.io())
-      .observeOn(AndroidSchedulers.mainThread());
-  @NonNull
-  private final MaybeTransformer maybeIoTransformer = upstream -> upstream
-      .subscribeOn(Schedulers.io())
-      .observeOn(AndroidSchedulers.mainThread());
-  @NonNull
-  private final ObservableTransformer observableIoTransformer = observable -> observable
-      .subscribeOn(Schedulers.io())
-      .observeOn(AndroidSchedulers.mainThread());
-  @NonNull
-  private final SingleTransformer singleIoTransformer = upstream -> upstream
-      .subscribeOn(Schedulers.io())
-      .observeOn(AndroidSchedulers.mainThread());
-
   protected Controller() {
     Injector.inject(this);
-  }
-
-  /**
-   * Provides the Io schedule {@link Completable} transformation.
-   * Subscribes the stream to Io bound {@link Schedulers} and observes it in the {Android main thread.
-   *
-   * @return The stream with the schedule transformation
-   */
-  @CheckResult
-  @NonNull
-  protected CompletableTransformer applyCompletableIoSchedulers() {
-    return completableIoTransformer;
-  }
-
-  /**
-   * Provides the Io schedule {@link Observable} transformation.
-   * Subscribes the stream to Io bound {@link Flowable} and observes it in the {Android main thread.
-   *
-   * @return The stream with the schedule transformation
-   */
-  @CheckResult
-  @NonNull
-  protected <T> FlowableTransformer<T, T> applyFlowableIoSchedulers() {
-    //noinspection unchecked
-    return (FlowableTransformer<T, T>) flowableIoTransformer;
-  }
-
-  /**
-   * Provides the Io schedule {@link Maybe} transformation.
-   * Subscribes the stream to Io bound {@link Schedulers} and observes it in the {Android main thread.
-   *
-   * @return The stream with the schedule transformation
-   */
-  @CheckResult
-  @NonNull
-  protected <T> MaybeTransformer<T, T> applyMaybeIoSchedulers() {
-    //noinspection unchecked
-    return (MaybeTransformer<T, T>) maybeIoTransformer;
-  }
-
-  /**
-   * Provides the Io schedule {@link Observable} transformation.
-   * Subscribes the stream to Io bound {@link Schedulers} and observes it in the {Android main thread.
-   *
-   * @return The stream with the schedule transformation
-   */
-  @CheckResult
-  @NonNull
-  protected <T> ObservableTransformer<T, T> applyObservableIoSchedulers() {
-    //noinspection unchecked
-    return (ObservableTransformer<T, T>) observableIoTransformer;
   }
 
   /**
@@ -107,8 +35,138 @@ public abstract class Controller {
    */
   @CheckResult
   @NonNull
+  protected CompletableTransformer applyCompletableIoSchedulersTransformation() {
+    return RxTransformerHelper.completableIoTransformer;
+  }
+
+  /**
+   * Provides the Io schedule {@link Single} transformation.
+   * Subscribes the stream to Io bound {@link Schedulers} and observes it in the {Android main thread.
+   *
+   * @return The stream with the schedule transformation
+   */
+  @CheckResult
+  @NonNull
+  protected <T> FlowableTransformer<T, T> applyFlowableIoSchedulersTransformation() {
+    //noinspection unchecked
+    return (FlowableTransformer<T, T>) RxTransformerHelper.flowableIoTransformer;
+  }
+
+  /**
+   * Provides the Io schedule {@link Single} transformation.
+   * Subscribes the stream to Io bound {@link Schedulers} and observes it in the {Android main thread.
+   *
+   * @return The stream with the schedule transformation
+   */
+  @CheckResult
+  @NonNull
+  protected <T> MaybeTransformer<T, T> applyMaybeIoSchedulersTransformation() {
+    //noinspection unchecked
+    return (MaybeTransformer<T, T>) RxTransformerHelper.maybeIoTransformer;
+  }
+
+  /**
+   * Provides the Io schedule {@link Single} transformation.
+   * Subscribes the stream to Io bound {@link Schedulers} and observes it in the {Android main thread.
+   *
+   * @return The stream with the schedule transformation
+   */
+  @CheckResult
+  @NonNull
+  protected <T> ObservableTransformer<T, T> applyObservableIoSchedulersTransformation() {
+    //noinspection unchecked
+    return (ObservableTransformer<T, T>) RxTransformerHelper.observableIoTransformer;
+  }
+
+  /**
+   * Provides the Io schedule {@link Single} transformation.
+   * Subscribes the stream to Io bound {@link Schedulers} and observes it in the {Android main thread.
+   *
+   * @return The stream with the schedule transformation
+   */
+  @CheckResult
+  @NonNull
+  protected <T> SingleTransformer<T, T> applySingleIoSchedulersTransformation() {
+    //noinspection unchecked
+    return (SingleTransformer<T, T>) RxTransformerHelper.singleIoTransformer;
+  }
+
+  /**
+   * @deprecated
+   *
+   * Provides the Io schedule {@link Completable} transformation.
+   * Subscribes the stream to Io bound {@link Schedulers} and observes it in the {Android main thread.
+   *
+   * @return The stream with the schedule transformation
+   */
+  @CheckResult
+  @Deprecated
+  @NonNull
+  protected CompletableTransformer applyCompletableIoSchedulers() {
+    return RxTransformerHelper.completableIoAndMainThreadTransformer;
+  }
+
+  /**
+   * @deprecated
+   *
+   * Provides the Io schedule {@link Observable} transformation.
+   * Subscribes the stream to Io bound {@link Flowable} and observes it in the {Android main thread.
+   *
+   * @return The stream with the schedule transformation
+   */
+  @CheckResult
+  @Deprecated
+  @NonNull
+  protected <T> FlowableTransformer<T, T> applyFlowableIoSchedulers() {
+    //noinspection unchecked
+    return (FlowableTransformer<T, T>) RxTransformerHelper.flowableIoAndMainThreadTransformer;
+  }
+
+  /**
+   * @deprecated
+   *
+   * Provides the Io schedule {@link Maybe} transformation.
+   * Subscribes the stream to Io bound {@link Schedulers} and observes it in the {Android main thread.
+   *
+   * @return The stream with the schedule transformation
+   */
+  @CheckResult
+  @Deprecated
+  @NonNull
+  protected <T> MaybeTransformer<T, T> applyMaybeIoSchedulers() {
+    //noinspection unchecked
+    return (MaybeTransformer<T, T>) RxTransformerHelper.maybeIoAndMainThreadTransformer;
+  }
+
+  /**
+   * @deprecated
+   *
+   * Provides the Io schedule {@link Observable} transformation.
+   * Subscribes the stream to Io bound {@link Schedulers} and observes it in the {Android main thread.
+   *
+   * @return The stream with the schedule transformation
+   */
+  @CheckResult
+  @Deprecated
+  @NonNull
+  protected <T> ObservableTransformer<T, T> applyObservableIoSchedulers() {
+    //noinspection unchecked
+    return (ObservableTransformer<T, T>) RxTransformerHelper.observableIoAndMainThreadTransformer;
+  }
+
+  /**
+   * @deprecated
+   *
+   * Provides the Io schedule {@link Single} transformation.
+   * Subscribes the stream to Io bound {@link Schedulers} and observes it in the {Android main thread.
+   *
+   * @return The stream with the schedule transformation
+   */
+  @CheckResult
+  @Deprecated
+  @NonNull
   protected <T> SingleTransformer<T, T> applySingleIoSchedulers() {
     //noinspection unchecked
-    return (SingleTransformer<T, T>) singleIoTransformer;
+    return (SingleTransformer<T, T>) RxTransformerHelper.singleIoAndMainThreadTransformer;
   }
 }

--- a/core/src/main/java/com/xmartlabs/bigbang/core/controller/Controller.java
+++ b/core/src/main/java/com/xmartlabs/bigbang/core/controller/Controller.java
@@ -41,7 +41,7 @@ public abstract class Controller {
    */
   @Deprecated
   @NonNull
-  public static final CompletableTransformer completableIoAndMainThreadTransformer = upstream -> upstream
+  private final CompletableTransformer completableIoAndMainThreadTransformer = upstream -> upstream
       .subscribeOn(Schedulers.io())
       .observeOn(AndroidSchedulers.mainThread());
 
@@ -56,7 +56,7 @@ public abstract class Controller {
    */
   @Deprecated
   @NonNull
-  public static final FlowableTransformer flowableIoAndMainThreadTransformer = upstream -> upstream
+  private final FlowableTransformer flowableIoAndMainThreadTransformer = upstream -> upstream
       .subscribeOn(Schedulers.io())
       .observeOn(AndroidSchedulers.mainThread());
 
@@ -71,7 +71,7 @@ public abstract class Controller {
    */
   @Deprecated
   @NonNull
-  public static final MaybeTransformer maybeIoAndMainThreadTransformer = upstream -> upstream
+  private final MaybeTransformer maybeIoAndMainThreadTransformer = upstream -> upstream
       .subscribeOn(Schedulers.io())
       .observeOn(AndroidSchedulers.mainThread());
 
@@ -86,7 +86,7 @@ public abstract class Controller {
    */
   @Deprecated
   @NonNull
-  public static final ObservableTransformer observableIoAndMainThreadTransformer = observable -> observable
+  private final ObservableTransformer observableIoAndMainThreadTransformer = observable -> observable
       .subscribeOn(Schedulers.io())
       .observeOn(AndroidSchedulers.mainThread());
 
@@ -101,7 +101,7 @@ public abstract class Controller {
    */
   @Deprecated
   @NonNull
-  public static final SingleTransformer singleIoAndMainThreadTransformer = upstream -> upstream
+  private final SingleTransformer singleIoAndMainThreadTransformer = upstream -> upstream
       .subscribeOn(Schedulers.io())
       .observeOn(AndroidSchedulers.mainThread());
 

--- a/core/src/main/java/com/xmartlabs/bigbang/core/controller/Controller.java
+++ b/core/src/main/java/com/xmartlabs/bigbang/core/controller/Controller.java
@@ -50,7 +50,7 @@ public abstract class Controller {
    * to decide when to observe on the main thread. Instead of this, use
    * {@link RxTransformerHelper#flowableIoTransformer} (it subscribes and observes on Io bound {@link Schedulers})
    *
-   * SingleTransformer that subscribes the stream in the Io {@link Schedulers} and observes
+   * FlowableTransformer that subscribes the stream in the Io {@link Schedulers} and observes
    * it on the {Android main thread.
    *
    */
@@ -65,7 +65,7 @@ public abstract class Controller {
    * to decide when to observe on the main thread. Instead of this, use
    * {@link RxTransformerHelper#maybeIoTransformer} (it subscribes and observes on Io bound {@link Schedulers})
    *
-   * SingleTransformer that subscribes the stream in the Io {@link Schedulers} and observes
+   * MaybeTransformer that subscribes the stream in the Io {@link Schedulers} and observes
    * it on the {Android main thread.
    *
    */
@@ -80,7 +80,7 @@ public abstract class Controller {
    * to decide when to observe on the main thread. Instead of this, use
    * {@link RxTransformerHelper#observableIoTransformer} (it subscribes and observes on Io bound {@link Schedulers})
    *
-   * SingleTransformer that subscribes the stream in the Io {@link Schedulers} and observes
+   * ObservableTransformer that subscribes the stream in the Io {@link Schedulers} and observes
    * it on the {Android main thread.
    *
    */
@@ -145,7 +145,7 @@ public abstract class Controller {
   /**
    * @deprecated The transformation shouldn't observe on the {Android main thread. You should be the one
    * to decide when to observe on the main thread. Instead of this, use
-   * {@link SchedulersTransformationHelper#applySingleIoSchedulersTransformation()}
+   * {@link SchedulersTransformationHelper#applyMaybeIoSchedulersTransformation()}
    * (it subscribes and observes on Io bound {@link Schedulers})
    *
    * Provides the Io schedule {@link Maybe} transformation.
@@ -164,7 +164,7 @@ public abstract class Controller {
   /**
    * @deprecated The transformation shouldn't observe on the {Android main thread. You should be the one
    * to decide when to observe on the main thread. Instead of this, use
-   * {@link SchedulersTransformationHelper#applySingleIoSchedulersTransformation()}
+   * {@link SchedulersTransformationHelper#applyObservableIoSchedulersTransformation()}
    * (it subscribes and observes on Io bound {@link Schedulers})
    *
    * Provides the Io schedule {@link Observable} transformation.

--- a/core/src/main/java/com/xmartlabs/bigbang/core/controller/EntityController.java
+++ b/core/src/main/java/com/xmartlabs/bigbang/core/controller/EntityController.java
@@ -62,7 +62,7 @@ public abstract class EntityController<Id, E extends EntityWithId<Id>, Condition
         .scan((databaseEntities, serviceEntities) ->
             entityDao.deleteAndInsertEntities(serviceEntities, conditions).blockingGet()
         )
-        .compose(applyFlowableIoSchedulers());
+        .compose(applyFlowableIoSchedulersTransformation());
   }
 
   /**

--- a/core/src/main/java/com/xmartlabs/bigbang/core/controller/EntityController.java
+++ b/core/src/main/java/com/xmartlabs/bigbang/core/controller/EntityController.java
@@ -4,7 +4,7 @@ import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
 
 import com.annimon.stream.Optional;
-import com.xmartlabs.bigbang.core.helper.IoSchedulersTransformationHelper;
+import com.xmartlabs.bigbang.core.helper.SchedulersTransformationHelper;
 import com.xmartlabs.bigbang.core.helper.function.BiFunction;
 import com.xmartlabs.bigbang.core.helper.function.Function;
 import com.xmartlabs.bigbang.core.model.EntityWithId;
@@ -55,7 +55,7 @@ public abstract class EntityController<Id, E extends EntityWithId<Id>, Condition
         .concatArrayDelayError(
             entityDao.getEntities(conditions).toFlowable(),
             serviceCall
-                .compose(IoSchedulersTransformationHelper.applySingleIoSchedulersTransformation())
+                .compose(SchedulersTransformationHelper.applySingleIoSchedulersTransformation())
                 .toFlowable()
         )
         .subscribeOn(Schedulers.io())
@@ -63,7 +63,7 @@ public abstract class EntityController<Id, E extends EntityWithId<Id>, Condition
         .scan((databaseEntities, serviceEntities) ->
             entityDao.deleteAndInsertEntities(serviceEntities, conditions).blockingGet()
         )
-        .compose(IoSchedulersTransformationHelper.applyFlowableIoSchedulersTransformation());
+        .compose(SchedulersTransformationHelper.applyFlowableIoSchedulersTransformation());
   }
 
   /**
@@ -113,7 +113,7 @@ public abstract class EntityController<Id, E extends EntityWithId<Id>, Condition
   @SuppressWarnings({"unused", "WeakerAccess"})
   protected Single<E> getServiceEntity(@NonNull Function<Id, Single<E>> serviceCall, Id id) {
     return serviceCall.apply(id)
-        .compose(IoSchedulersTransformationHelper.applySingleIoSchedulersTransformation())
+        .compose(SchedulersTransformationHelper.applySingleIoSchedulersTransformation())
         .doOnSuccess(entityDao::updateEntity);
   }
 
@@ -128,7 +128,7 @@ public abstract class EntityController<Id, E extends EntityWithId<Id>, Condition
   @SuppressWarnings({"unused", "WeakerAccess"})
   protected Single<E> createEntityAndGetValue(@NonNull Single<E> serviceCall) {
     return serviceCall
-        .compose(IoSchedulersTransformationHelper.applySingleIoSchedulersTransformation ())
+        .compose(SchedulersTransformationHelper.applySingleIoSchedulersTransformation ())
         .flatMap(entityDao::createEntity);
   }
 
@@ -174,7 +174,7 @@ public abstract class EntityController<Id, E extends EntityWithId<Id>, Condition
   @SuppressWarnings({"unused", "WeakerAccess"})
   protected Single<E> updateEntityAndGetValue(E entity, Completable completable) {
     return completable
-        .compose(IoSchedulersTransformationHelper.applyCompletableIoSchedulersTransformation())
+        .compose(SchedulersTransformationHelper.applyCompletableIoSchedulersTransformation())
         .toSingleDefault(entity)
         .flatMap(entityDao::updateEntity);
   }
@@ -206,7 +206,7 @@ public abstract class EntityController<Id, E extends EntityWithId<Id>, Condition
   @SuppressWarnings({"unused", "WeakerAccess"})
   protected Completable deleteEntity(@NonNull Function<Id, Completable> serviceCall, @NonNull Id entityId) {
     return serviceCall.apply(entityId)
-        .compose(IoSchedulersTransformationHelper.applyCompletableIoSchedulersTransformation())
+        .compose(SchedulersTransformationHelper.applyCompletableIoSchedulersTransformation())
         .concatWith(entityDao.deleteEntityWithId(entityId));
   }
 
@@ -223,7 +223,7 @@ public abstract class EntityController<Id, E extends EntityWithId<Id>, Condition
   protected Completable deleteEntity(@NonNull Function<Id, Completable> serviceCall, @NonNull E entity) {
     return Optional.of(entity.getId())
         .map(id -> serviceCall.apply(id)
-            .compose(IoSchedulersTransformationHelper.applyCompletableIoSchedulersTransformation())
+            .compose(SchedulersTransformationHelper.applyCompletableIoSchedulersTransformation())
             .concatWith(entityDao.deleteEntity(entity)))
         .orElse(Completable.error(() -> new IllegalStateException("Entity id cannot be null")));
   }

--- a/core/src/main/java/com/xmartlabs/bigbang/core/controller/EntityController.java
+++ b/core/src/main/java/com/xmartlabs/bigbang/core/controller/EntityController.java
@@ -4,6 +4,7 @@ import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
 
 import com.annimon.stream.Optional;
+import com.xmartlabs.bigbang.core.helper.IoSchedulersTransformationHelper;
 import com.xmartlabs.bigbang.core.helper.function.BiFunction;
 import com.xmartlabs.bigbang.core.helper.function.Function;
 import com.xmartlabs.bigbang.core.model.EntityWithId;
@@ -54,7 +55,7 @@ public abstract class EntityController<Id, E extends EntityWithId<Id>, Condition
         .concatArrayDelayError(
             entityDao.getEntities(conditions).toFlowable(),
             serviceCall
-                .compose(entityServiceProvider.applySingleServiceTransformation())
+                .compose(IoSchedulersTransformationHelper.applySingleIoSchedulersTransformation())
                 .toFlowable()
         )
         .subscribeOn(Schedulers.io())
@@ -62,7 +63,7 @@ public abstract class EntityController<Id, E extends EntityWithId<Id>, Condition
         .scan((databaseEntities, serviceEntities) ->
             entityDao.deleteAndInsertEntities(serviceEntities, conditions).blockingGet()
         )
-        .compose(applyFlowableIoSchedulersTransformation());
+        .compose(IoSchedulersTransformationHelper.applyFlowableIoSchedulersTransformation());
   }
 
   /**
@@ -112,7 +113,7 @@ public abstract class EntityController<Id, E extends EntityWithId<Id>, Condition
   @SuppressWarnings({"unused", "WeakerAccess"})
   protected Single<E> getServiceEntity(@NonNull Function<Id, Single<E>> serviceCall, Id id) {
     return serviceCall.apply(id)
-        .compose(entityServiceProvider.applySingleServiceTransformation())
+        .compose(IoSchedulersTransformationHelper.applySingleIoSchedulersTransformation())
         .doOnSuccess(entityDao::updateEntity);
   }
 
@@ -127,7 +128,7 @@ public abstract class EntityController<Id, E extends EntityWithId<Id>, Condition
   @SuppressWarnings({"unused", "WeakerAccess"})
   protected Single<E> createEntityAndGetValue(@NonNull Single<E> serviceCall) {
     return serviceCall
-        .compose(entityServiceProvider.applySingleServiceTransformation())
+        .compose(IoSchedulersTransformationHelper.applySingleIoSchedulersTransformation ())
         .flatMap(entityDao::createEntity);
   }
 
@@ -173,7 +174,7 @@ public abstract class EntityController<Id, E extends EntityWithId<Id>, Condition
   @SuppressWarnings({"unused", "WeakerAccess"})
   protected Single<E> updateEntityAndGetValue(E entity, Completable completable) {
     return completable
-        .compose(entityServiceProvider.applyCompletableServiceTransformation())
+        .compose(IoSchedulersTransformationHelper.applyCompletableIoSchedulersTransformation())
         .toSingleDefault(entity)
         .flatMap(entityDao::updateEntity);
   }
@@ -205,7 +206,7 @@ public abstract class EntityController<Id, E extends EntityWithId<Id>, Condition
   @SuppressWarnings({"unused", "WeakerAccess"})
   protected Completable deleteEntity(@NonNull Function<Id, Completable> serviceCall, @NonNull Id entityId) {
     return serviceCall.apply(entityId)
-        .compose(entityServiceProvider.applyCompletableServiceTransformation())
+        .compose(IoSchedulersTransformationHelper.applyCompletableIoSchedulersTransformation())
         .concatWith(entityDao.deleteEntityWithId(entityId));
   }
 
@@ -222,7 +223,7 @@ public abstract class EntityController<Id, E extends EntityWithId<Id>, Condition
   protected Completable deleteEntity(@NonNull Function<Id, Completable> serviceCall, @NonNull E entity) {
     return Optional.of(entity.getId())
         .map(id -> serviceCall.apply(id)
-            .compose(entityServiceProvider.applyCompletableServiceTransformation())
+            .compose(IoSchedulersTransformationHelper.applyCompletableIoSchedulersTransformation())
             .concatWith(entityDao.deleteEntity(entity)))
         .orElse(Completable.error(() -> new IllegalStateException("Entity id cannot be null")));
   }

--- a/core/src/main/java/com/xmartlabs/bigbang/core/controller/EntityServiceProvider.java
+++ b/core/src/main/java/com/xmartlabs/bigbang/core/controller/EntityServiceProvider.java
@@ -22,12 +22,14 @@ import io.reactivex.SingleTransformer;
  */
 public interface EntityServiceProvider<Id, E extends EntityWithId<Id>> {
   /**
+   * @deprecated
    *
    * Provides the service {@link Completable} transformation.
    * It could be used to sign out the user when getting a service error for example.
    *
    * @return The {@link Completable} transformation
    */
+  @Deprecated
   @CheckResult
   @NonNull
   CompletableTransformer applyCompletableServiceTransformation();
@@ -44,6 +46,7 @@ public interface EntityServiceProvider<Id, E extends EntityWithId<Id>> {
   <S> MaybeTransformer<S, S> applyMaybeServiceTransformation();
 
   /**
+   * @deprecated
    *
    * Provides the service {@link Single} transformation.
    * It could be used to sign out the user when getting a service error for example.
@@ -51,6 +54,7 @@ public interface EntityServiceProvider<Id, E extends EntityWithId<Id>> {
    * @param <S> Type of the item emitted by the {@link Single}
    * @return The {@link Single} transformation
    */
+  @Deprecated
   @CheckResult
   @NonNull
   <S> SingleTransformer<S, S> applySingleServiceTransformation();

--- a/core/src/main/java/com/xmartlabs/bigbang/core/controller/EntityServiceProvider.java
+++ b/core/src/main/java/com/xmartlabs/bigbang/core/controller/EntityServiceProvider.java
@@ -10,6 +10,7 @@ import java.util.List;
 import io.reactivex.Completable;
 import io.reactivex.CompletableTransformer;
 import io.reactivex.Maybe;
+import io.reactivex.MaybeTransformer;
 import io.reactivex.Single;
 import io.reactivex.SingleTransformer;
 
@@ -21,6 +22,32 @@ import io.reactivex.SingleTransformer;
  */
 public interface EntityServiceProvider<Id, E extends EntityWithId<Id>> {
   /**
+   * @deprecated
+   *
+   * Provides the service {@link Completable} transformation.
+   * It could be used to sign out the user when getting a service error for example.
+   *
+   * @return The {@link Completable} transformation
+   */
+  @CheckResult
+  @Deprecated
+  @NonNull
+  CompletableTransformer applyCompletableServiceTransformation();
+
+  /**
+   *
+   * Provides the service {@link Maybe} transformation.
+   * It could be used to sign out the user when getting a service error for example.
+   *
+   * @return The {@link Maybe} transformation
+   */
+  @CheckResult
+  @NonNull
+  <S> MaybeTransformer<S, S> applyMaybeServiceTransformation();
+
+  /**
+   * @deprecated
+   *
    * Provides the service {@link Single} transformation.
    * It could be used to sign out the user when getting a service error for example.
    *
@@ -28,18 +55,9 @@ public interface EntityServiceProvider<Id, E extends EntityWithId<Id>> {
    * @return The {@link Single} transformation
    */
   @CheckResult
+  @Deprecated
   @NonNull
   <S> SingleTransformer<S, S> applySingleServiceTransformation();
-
-  /**
-   * Provides the service {@link Completable} transformation.
-   * It could be used to sign out the user when getting a service error for example.
-   *
-   * @return The {@link Completable} transformation
-   */
-  @CheckResult
-  @NonNull
-  CompletableTransformer applyCompletableServiceTransformation();
 
   /**
    * Provides an entity {@link E} from a service which gives a list of {@link E}.

--- a/core/src/main/java/com/xmartlabs/bigbang/core/controller/EntityServiceProvider.java
+++ b/core/src/main/java/com/xmartlabs/bigbang/core/controller/EntityServiceProvider.java
@@ -22,7 +22,6 @@ import io.reactivex.SingleTransformer;
  */
 public interface EntityServiceProvider<Id, E extends EntityWithId<Id>> {
   /**
-   * @deprecated
    *
    * Provides the service {@link Completable} transformation.
    * It could be used to sign out the user when getting a service error for example.
@@ -30,7 +29,6 @@ public interface EntityServiceProvider<Id, E extends EntityWithId<Id>> {
    * @return The {@link Completable} transformation
    */
   @CheckResult
-  @Deprecated
   @NonNull
   CompletableTransformer applyCompletableServiceTransformation();
 
@@ -46,7 +44,6 @@ public interface EntityServiceProvider<Id, E extends EntityWithId<Id>> {
   <S> MaybeTransformer<S, S> applyMaybeServiceTransformation();
 
   /**
-   * @deprecated
    *
    * Provides the service {@link Single} transformation.
    * It could be used to sign out the user when getting a service error for example.
@@ -55,7 +52,6 @@ public interface EntityServiceProvider<Id, E extends EntityWithId<Id>> {
    * @return The {@link Single} transformation
    */
   @CheckResult
-  @Deprecated
   @NonNull
   <S> SingleTransformer<S, S> applySingleServiceTransformation();
 

--- a/core/src/main/java/com/xmartlabs/bigbang/core/controller/EntityServiceProvider.java
+++ b/core/src/main/java/com/xmartlabs/bigbang/core/controller/EntityServiceProvider.java
@@ -9,8 +9,12 @@ import java.util.List;
 
 import io.reactivex.Completable;
 import io.reactivex.CompletableTransformer;
+import io.reactivex.Flowable;
+import io.reactivex.FlowableTransformer;
 import io.reactivex.Maybe;
 import io.reactivex.MaybeTransformer;
+import io.reactivex.Observable;
+import io.reactivex.ObservableTransformer;
 import io.reactivex.Single;
 import io.reactivex.SingleTransformer;
 
@@ -29,21 +33,10 @@ public interface EntityServiceProvider<Id, E extends EntityWithId<Id>> {
    *
    * @return The {@link Completable} transformation
    */
-  @Deprecated
   @CheckResult
+  @Deprecated
   @NonNull
   CompletableTransformer applyCompletableServiceTransformation();
-
-  /**
-   *
-   * Provides the service {@link Maybe} transformation.
-   * It could be used to sign out the user when getting a service error for example.
-   *
-   * @return The {@link Maybe} transformation
-   */
-  @CheckResult
-  @NonNull
-  <S> MaybeTransformer<S, S> applyMaybeServiceTransformation();
 
   /**
    * @deprecated

--- a/core/src/main/java/com/xmartlabs/bigbang/core/controller/SharedPreferencesController.java
+++ b/core/src/main/java/com/xmartlabs/bigbang/core/controller/SharedPreferencesController.java
@@ -10,6 +10,7 @@ import com.annimon.stream.Objects;
 import com.annimon.stream.Optional;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
+import com.xmartlabs.bigbang.core.helper.IoSchedulersTransformationHelper;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -167,7 +168,7 @@ public class SharedPreferencesController extends Controller {
           .putString(key, serializedValue)
           .commit();
       return value;
-    }).compose(applySingleIoSchedulersTransformation());
+    }).compose(IoSchedulersTransformationHelper.applySingleIoSchedulersTransformation());
   }
 
   /**

--- a/core/src/main/java/com/xmartlabs/bigbang/core/controller/SharedPreferencesController.java
+++ b/core/src/main/java/com/xmartlabs/bigbang/core/controller/SharedPreferencesController.java
@@ -10,7 +10,7 @@ import com.annimon.stream.Objects;
 import com.annimon.stream.Optional;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
-import com.xmartlabs.bigbang.core.helper.IoSchedulersTransformationHelper;
+import com.xmartlabs.bigbang.core.helper.SchedulersTransformationHelper;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -168,7 +168,7 @@ public class SharedPreferencesController extends Controller {
           .putString(key, serializedValue)
           .commit();
       return value;
-    }).compose(IoSchedulersTransformationHelper.applySingleIoSchedulersTransformation());
+    }).compose(SchedulersTransformationHelper.applySingleIoSchedulersTransformation());
   }
 
   /**

--- a/core/src/main/java/com/xmartlabs/bigbang/core/controller/SharedPreferencesController.java
+++ b/core/src/main/java/com/xmartlabs/bigbang/core/controller/SharedPreferencesController.java
@@ -17,7 +17,6 @@ import java.util.Map;
 import javax.inject.Inject;
 
 import io.reactivex.Single;
-import io.reactivex.schedulers.Schedulers;
 import timber.log.Timber;
 
 /**
@@ -168,7 +167,7 @@ public class SharedPreferencesController extends Controller {
           .putString(key, serializedValue)
           .commit();
       return value;
-    }).compose(applySingleIoSchedulers());
+    }).compose(applySingleIoSchedulersTransformation());
   }
 
   /**

--- a/core/src/main/java/com/xmartlabs/bigbang/core/helper/IoSchedulersTransformationHelper.java
+++ b/core/src/main/java/com/xmartlabs/bigbang/core/helper/IoSchedulersTransformationHelper.java
@@ -12,7 +12,7 @@ import io.reactivex.SingleTransformer;
 import io.reactivex.schedulers.Schedulers;
 
 /**
- * Created by bruno on 19/09/18.
+ * Contains the different Io Schedulers transformations for main RxJava operators.
  */
 public class IoSchedulersTransformationHelper {
   /**

--- a/core/src/main/java/com/xmartlabs/bigbang/core/helper/IoSchedulersTransformationHelper.java
+++ b/core/src/main/java/com/xmartlabs/bigbang/core/helper/IoSchedulersTransformationHelper.java
@@ -1,0 +1,81 @@
+package com.xmartlabs.bigbang.core.helper;
+
+import android.support.annotation.CheckResult;
+import android.support.annotation.NonNull;
+
+import io.reactivex.CompletableTransformer;
+import io.reactivex.FlowableTransformer;
+import io.reactivex.MaybeTransformer;
+import io.reactivex.ObservableTransformer;
+import io.reactivex.Single;
+import io.reactivex.SingleTransformer;
+import io.reactivex.schedulers.Schedulers;
+
+/**
+ * Created by bruno on 19/09/18.
+ */
+public class IoSchedulersTransformationHelper {
+  /**
+   * Provides the Io schedule {@link Single} transformation.
+   * Subscribes and observes the stream in the Io {@link Schedulers}.
+   *
+   * @return The stream with the schedule transformation
+   */
+  @CheckResult
+  @NonNull
+  public static CompletableTransformer applyCompletableIoSchedulersTransformation() {
+    return RxTransformerHelper.completableIoTransformer;
+  }
+
+  /**
+   * Provides the Io schedule {@link Single} transformation.
+   * Subscribes and observes the stream in the Io {@link Schedulers}.
+   *
+   * @return The stream with the schedule transformation
+   */
+  @CheckResult
+  @NonNull
+  public static <T> FlowableTransformer<T, T> applyFlowableIoSchedulersTransformation() {
+    //noinspection unchecked
+    return (FlowableTransformer<T, T>) RxTransformerHelper.flowableIoTransformer;
+  }
+
+  /**
+   * Provides the Io schedule {@link Single} transformation.
+   * Subscribes and observes the stream in the Io {@link Schedulers}.
+   *
+   * @return The stream with the schedule transformation
+   */
+  @CheckResult
+  @NonNull
+  public static <T> MaybeTransformer<T, T> applyMaybeIoSchedulersTransformation() {
+    //noinspection unchecked
+    return (MaybeTransformer<T, T>) RxTransformerHelper.maybeIoTransformer;
+  }
+
+  /**
+   * Provides the Io schedule {@link Single} transformation.
+   * Subscribes and observes the stream in the Io {@link Schedulers}.
+   *
+   * @return The stream with the schedule transformation
+   */
+  @CheckResult
+  @NonNull
+  public static <T> ObservableTransformer<T, T> applyObservableIoSchedulersTransformation() {
+    //noinspection unchecked
+    return (ObservableTransformer<T, T>) RxTransformerHelper.observableIoTransformer;
+  }
+
+  /**
+   * Provides the Io schedule {@link Single} transformation.
+   * Subscribes and observes the stream on Io bound {@link Schedulers}.
+   *
+   * @return The stream with the schedule transformation
+   */
+  @CheckResult
+  @NonNull
+  public static <T> SingleTransformer<T, T> applySingleIoSchedulersTransformation() {
+    //noinspection unchecked
+    return (SingleTransformer<T, T>) RxTransformerHelper.singleIoTransformer;
+  }
+}

--- a/core/src/main/java/com/xmartlabs/bigbang/core/helper/RxTransformerHelper.java
+++ b/core/src/main/java/com/xmartlabs/bigbang/core/helper/RxTransformerHelper.java
@@ -11,11 +11,11 @@ import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.schedulers.Schedulers;
 
 /**
- * Created by bruno on 1/12/18.
+ * Contains RXJava's Transformers
  */
 public class RxTransformerHelper {
   /**
-   *
+   * CompletableTransformer that subscribes and observes the stream on Io bound {@link Schedulers}.
    */
   @NonNull
   public static final CompletableTransformer completableIoTransformer = upstream -> upstream
@@ -23,7 +23,7 @@ public class RxTransformerHelper {
       .observeOn(Schedulers.io());
 
   /**
-   *
+   * FlowableTransformer that subscribes and observes the stream on Io bound {@link Schedulers}.
    */
   @NonNull
   public static final FlowableTransformer flowableIoTransformer = upstream -> upstream
@@ -31,7 +31,7 @@ public class RxTransformerHelper {
       .observeOn(Schedulers.io());
 
   /**
-   *
+   * MaybeTransformer that subscribes and observes the stream on Io bound {@link Schedulers}.
    */
   @NonNull
   public static final MaybeTransformer maybeIoTransformer = upstream -> upstream
@@ -39,7 +39,7 @@ public class RxTransformerHelper {
       .observeOn(Schedulers.io());
 
   /**
-   *
+   * ObservableTransformer that subscribes and observes the stream on Io bound {@link Schedulers}.
    */
   @NonNull
   public static final ObservableTransformer observableIoTransformer = upstream -> upstream
@@ -47,7 +47,7 @@ public class RxTransformerHelper {
       .observeOn(Schedulers.io());
 
   /**
-   *
+   * SingleTransformer that subscribes and observes the stream on Io bound {@link Schedulers}.
    */
   @NonNull
   public static final SingleTransformer singleIoTransformer = upstream -> upstream
@@ -55,6 +55,12 @@ public class RxTransformerHelper {
       .observeOn(Schedulers.io());
 
   /**
+   * @deprecated The transformer shouldn't observe on the {Android main thread. You should be the one
+   * to decide when to observe on the main thread. Instead of this, use
+   * {@link #singleIoTransformer} (it subscribes and observes on Io bound {@link Schedulers})
+   *
+   * CompletableTransformer that subscribes the stream in the Io {@link Schedulers} and observes
+   * it on the {Android main thread.
    *
    */
   @Deprecated
@@ -64,6 +70,12 @@ public class RxTransformerHelper {
       .observeOn(AndroidSchedulers.mainThread());
 
   /**
+   * @deprecated The transformer shouldn't observe on the {Android main thread. You should be the one
+   * to decide when to observe on the main thread. Instead of this, use
+   * {@link #singleIoTransformer} (it subscribes and observes on Io bound {@link Schedulers})
+   *
+   * SingleTransformer that subscribes the stream in the Io {@link Schedulers} and observes
+   * it on the {Android main thread.
    *
    */
   @Deprecated
@@ -73,6 +85,12 @@ public class RxTransformerHelper {
       .observeOn(AndroidSchedulers.mainThread());
 
   /**
+   * @deprecated The transformer shouldn't observe on the {Android main thread. You should be the one
+   * to decide when to observe on the main thread. Instead of this, use
+   * {@link #singleIoTransformer} (it subscribes and observes on Io bound {@link Schedulers})
+   *
+   * SingleTransformer that subscribes the stream in the Io {@link Schedulers} and observes
+   * it on the {Android main thread.
    *
    */
   @Deprecated
@@ -82,6 +100,12 @@ public class RxTransformerHelper {
       .observeOn(AndroidSchedulers.mainThread());
 
   /**
+   * @deprecated The transformer shouldn't observe on the {Android main thread. You should be the one
+   * to decide when to observe on the main thread. Instead of this, use
+   * {@link #singleIoTransformer} (it subscribes and observes on Io bound {@link Schedulers})
+   *
+   * SingleTransformer that subscribes the stream in the Io {@link Schedulers} and observes
+   * it on the {Android main thread.
    *
    */
   @Deprecated
@@ -91,6 +115,12 @@ public class RxTransformerHelper {
       .observeOn(AndroidSchedulers.mainThread());
 
   /**
+   * @deprecated The transformer shouldn't observe on the {Android main thread. You should be the one
+   * to decide when to observe on the main thread. Instead of this, use
+   * {@link #singleIoTransformer} (it subscribes and observes on Io bound {@link Schedulers})
+   *
+   * SingleTransformer that subscribes the stream in the Io {@link Schedulers} and observes
+   * it on the {Android main thread.
    *
    */
   @Deprecated

--- a/core/src/main/java/com/xmartlabs/bigbang/core/helper/RxTransformerHelper.java
+++ b/core/src/main/java/com/xmartlabs/bigbang/core/helper/RxTransformerHelper.java
@@ -1,0 +1,101 @@
+package com.xmartlabs.bigbang.core.helper;
+
+import android.support.annotation.NonNull;
+
+import io.reactivex.CompletableTransformer;
+import io.reactivex.FlowableTransformer;
+import io.reactivex.MaybeTransformer;
+import io.reactivex.ObservableTransformer;
+import io.reactivex.SingleTransformer;
+import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.schedulers.Schedulers;
+
+/**
+ * Created by bruno on 1/12/18.
+ */
+public class RxTransformerHelper {
+  /**
+   *
+   */
+  @NonNull
+  public static final CompletableTransformer completableIoTransformer = upstream -> upstream
+      .subscribeOn(Schedulers.io())
+      .observeOn(Schedulers.io());
+
+  /**
+   *
+   */
+  @NonNull
+  public static final FlowableTransformer flowableIoTransformer = upstream -> upstream
+      .subscribeOn(Schedulers.io())
+      .observeOn(Schedulers.io());
+
+  /**
+   *
+   */
+  @NonNull
+  public static final MaybeTransformer maybeIoTransformer = upstream -> upstream
+      .subscribeOn(Schedulers.io())
+      .observeOn(Schedulers.io());
+
+  /**
+   *
+   */
+  @NonNull
+  public static final ObservableTransformer observableIoTransformer = upstream -> upstream
+      .subscribeOn(Schedulers.io())
+      .observeOn(Schedulers.io());
+
+  /**
+   *
+   */
+  @NonNull
+  public static final SingleTransformer singleIoTransformer = upstream -> upstream
+      .subscribeOn(Schedulers.io())
+      .observeOn(Schedulers.io());
+
+  /**
+   *
+   */
+  @Deprecated
+  @NonNull
+  public static final CompletableTransformer completableIoAndMainThreadTransformer = upstream -> upstream
+      .subscribeOn(Schedulers.io())
+      .observeOn(AndroidSchedulers.mainThread());
+
+  /**
+   *
+   */
+  @Deprecated
+  @NonNull
+  public static final FlowableTransformer flowableIoAndMainThreadTransformer = upstream -> upstream
+      .subscribeOn(Schedulers.io())
+      .observeOn(AndroidSchedulers.mainThread());
+
+  /**
+   *
+   */
+  @Deprecated
+  @NonNull
+  public static final MaybeTransformer maybeIoAndMainThreadTransformer = upstream -> upstream
+      .subscribeOn(Schedulers.io())
+      .observeOn(AndroidSchedulers.mainThread());
+
+  /**
+   *
+   */
+  @Deprecated
+  @NonNull
+  public static final ObservableTransformer observableIoAndMainThreadTransformer = observable -> observable
+      .subscribeOn(Schedulers.io())
+      .observeOn(AndroidSchedulers.mainThread());
+
+  /**
+   *
+   */
+  @Deprecated
+  @NonNull
+  public static final SingleTransformer singleIoAndMainThreadTransformer = upstream -> upstream
+      .subscribeOn(Schedulers.io())
+      .observeOn(AndroidSchedulers.mainThread());
+}

--- a/core/src/main/java/com/xmartlabs/bigbang/core/helper/RxTransformerHelper.java
+++ b/core/src/main/java/com/xmartlabs/bigbang/core/helper/RxTransformerHelper.java
@@ -18,7 +18,7 @@ public class RxTransformerHelper {
    * CompletableTransformer that subscribes and observes the stream on Io bound {@link Schedulers}.
    */
   @NonNull
-  public static final CompletableTransformer completableIoTransformer = upstream -> upstream
+  static final CompletableTransformer completableIoTransformer = upstream -> upstream
       .subscribeOn(Schedulers.io())
       .observeOn(Schedulers.io());
 
@@ -26,7 +26,7 @@ public class RxTransformerHelper {
    * FlowableTransformer that subscribes and observes the stream on Io bound {@link Schedulers}.
    */
   @NonNull
-  public static final FlowableTransformer flowableIoTransformer = upstream -> upstream
+  static final FlowableTransformer flowableIoTransformer = upstream -> upstream
       .subscribeOn(Schedulers.io())
       .observeOn(Schedulers.io());
 
@@ -34,7 +34,7 @@ public class RxTransformerHelper {
    * MaybeTransformer that subscribes and observes the stream on Io bound {@link Schedulers}.
    */
   @NonNull
-  public static final MaybeTransformer maybeIoTransformer = upstream -> upstream
+  static final MaybeTransformer maybeIoTransformer = upstream -> upstream
       .subscribeOn(Schedulers.io())
       .observeOn(Schedulers.io());
 
@@ -42,7 +42,7 @@ public class RxTransformerHelper {
    * ObservableTransformer that subscribes and observes the stream on Io bound {@link Schedulers}.
    */
   @NonNull
-  public static final ObservableTransformer observableIoTransformer = upstream -> upstream
+  static final ObservableTransformer observableIoTransformer = upstream -> upstream
       .subscribeOn(Schedulers.io())
       .observeOn(Schedulers.io());
 
@@ -50,82 +50,7 @@ public class RxTransformerHelper {
    * SingleTransformer that subscribes and observes the stream on Io bound {@link Schedulers}.
    */
   @NonNull
-  public static final SingleTransformer singleIoTransformer = upstream -> upstream
+  static final SingleTransformer singleIoTransformer = upstream -> upstream
       .subscribeOn(Schedulers.io())
       .observeOn(Schedulers.io());
-
-  /**
-   * @deprecated The transformer shouldn't observe on the {Android main thread. You should be the one
-   * to decide when to observe on the main thread. Instead of this, use
-   * {@link #singleIoTransformer} (it subscribes and observes on Io bound {@link Schedulers})
-   *
-   * CompletableTransformer that subscribes the stream in the Io {@link Schedulers} and observes
-   * it on the {Android main thread.
-   *
-   */
-  @Deprecated
-  @NonNull
-  public static final CompletableTransformer completableIoAndMainThreadTransformer = upstream -> upstream
-      .subscribeOn(Schedulers.io())
-      .observeOn(AndroidSchedulers.mainThread());
-
-  /**
-   * @deprecated The transformer shouldn't observe on the {Android main thread. You should be the one
-   * to decide when to observe on the main thread. Instead of this, use
-   * {@link #singleIoTransformer} (it subscribes and observes on Io bound {@link Schedulers})
-   *
-   * SingleTransformer that subscribes the stream in the Io {@link Schedulers} and observes
-   * it on the {Android main thread.
-   *
-   */
-  @Deprecated
-  @NonNull
-  public static final FlowableTransformer flowableIoAndMainThreadTransformer = upstream -> upstream
-      .subscribeOn(Schedulers.io())
-      .observeOn(AndroidSchedulers.mainThread());
-
-  /**
-   * @deprecated The transformer shouldn't observe on the {Android main thread. You should be the one
-   * to decide when to observe on the main thread. Instead of this, use
-   * {@link #singleIoTransformer} (it subscribes and observes on Io bound {@link Schedulers})
-   *
-   * SingleTransformer that subscribes the stream in the Io {@link Schedulers} and observes
-   * it on the {Android main thread.
-   *
-   */
-  @Deprecated
-  @NonNull
-  public static final MaybeTransformer maybeIoAndMainThreadTransformer = upstream -> upstream
-      .subscribeOn(Schedulers.io())
-      .observeOn(AndroidSchedulers.mainThread());
-
-  /**
-   * @deprecated The transformer shouldn't observe on the {Android main thread. You should be the one
-   * to decide when to observe on the main thread. Instead of this, use
-   * {@link #singleIoTransformer} (it subscribes and observes on Io bound {@link Schedulers})
-   *
-   * SingleTransformer that subscribes the stream in the Io {@link Schedulers} and observes
-   * it on the {Android main thread.
-   *
-   */
-  @Deprecated
-  @NonNull
-  public static final ObservableTransformer observableIoAndMainThreadTransformer = observable -> observable
-      .subscribeOn(Schedulers.io())
-      .observeOn(AndroidSchedulers.mainThread());
-
-  /**
-   * @deprecated The transformer shouldn't observe on the {Android main thread. You should be the one
-   * to decide when to observe on the main thread. Instead of this, use
-   * {@link #singleIoTransformer} (it subscribes and observes on Io bound {@link Schedulers})
-   *
-   * SingleTransformer that subscribes the stream in the Io {@link Schedulers} and observes
-   * it on the {Android main thread.
-   *
-   */
-  @Deprecated
-  @NonNull
-  public static final SingleTransformer singleIoAndMainThreadTransformer = upstream -> upstream
-      .subscribeOn(Schedulers.io())
-      .observeOn(AndroidSchedulers.mainThread());
 }

--- a/core/src/main/java/com/xmartlabs/bigbang/core/helper/SchedulersTransformationHelper.java
+++ b/core/src/main/java/com/xmartlabs/bigbang/core/helper/SchedulersTransformationHelper.java
@@ -3,9 +3,13 @@ package com.xmartlabs.bigbang.core.helper;
 import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
 
+import io.reactivex.Completable;
 import io.reactivex.CompletableTransformer;
+import io.reactivex.Flowable;
 import io.reactivex.FlowableTransformer;
+import io.reactivex.Maybe;
 import io.reactivex.MaybeTransformer;
+import io.reactivex.Observable;
 import io.reactivex.ObservableTransformer;
 import io.reactivex.Single;
 import io.reactivex.SingleTransformer;
@@ -14,9 +18,9 @@ import io.reactivex.schedulers.Schedulers;
 /**
  * Contains the different Io Schedulers transformations for main RxJava operators.
  */
-public class IoSchedulersTransformationHelper {
+public class SchedulersTransformationHelper {
   /**
-   * Provides the Io schedule {@link Single} transformation.
+   * Provides the Io schedule {@link Completable} transformation.
    * Subscribes and observes the stream in the Io {@link Schedulers}.
    *
    * @return The stream with the schedule transformation
@@ -28,7 +32,7 @@ public class IoSchedulersTransformationHelper {
   }
 
   /**
-   * Provides the Io schedule {@link Single} transformation.
+   * Provides the Io schedule {@link Flowable} transformation.
    * Subscribes and observes the stream in the Io {@link Schedulers}.
    *
    * @return The stream with the schedule transformation
@@ -41,7 +45,7 @@ public class IoSchedulersTransformationHelper {
   }
 
   /**
-   * Provides the Io schedule {@link Single} transformation.
+   * Provides the Io schedule {@link Maybe} transformation.
    * Subscribes and observes the stream in the Io {@link Schedulers}.
    *
    * @return The stream with the schedule transformation
@@ -54,7 +58,7 @@ public class IoSchedulersTransformationHelper {
   }
 
   /**
-   * Provides the Io schedule {@link Single} transformation.
+   * Provides the Io schedule {@link Observable} transformation.
    * Subscribes and observes the stream in the Io {@link Schedulers}.
    *
    * @return The stream with the schedule transformation

--- a/retrofit/src/main/java/com/xmartlabs/bigbang/retrofit/controller/ServiceController.java
+++ b/retrofit/src/main/java/com/xmartlabs/bigbang/retrofit/controller/ServiceController.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 import io.reactivex.CompletableTransformer;
 import io.reactivex.Maybe;
+import io.reactivex.MaybeTransformer;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.SingleTransformer;
@@ -25,17 +26,26 @@ import io.reactivex.SingleTransformer;
 public abstract class ServiceController<Id, E extends EntityWithId<Id>> extends Controller
     implements EntityServiceProvider<Id, E> {
   @CheckResult
+  @Deprecated
   @NonNull
   @Override
-  public <S> SingleTransformer<S, S> applySingleServiceTransformation() {
-    return applySingleIoSchedulers();
+  public CompletableTransformer applyCompletableServiceTransformation() {
+    return applyCompletableIoSchedulers();
   }
 
   @CheckResult
   @NonNull
   @Override
-  public CompletableTransformer applyCompletableServiceTransformation() {
-    return applyCompletableIoSchedulers();
+  public <S> MaybeTransformer<S, S> applyMaybeServiceTransformation() {
+    return applyMaybeIoSchedulersTransformation();
+  }
+
+  @CheckResult
+  @Deprecated
+  @NonNull
+  @Override
+  public <S> SingleTransformer<S, S> applySingleServiceTransformation() {
+    return applySingleIoSchedulers();
   }
 
   @CheckResult

--- a/retrofit/src/main/java/com/xmartlabs/bigbang/retrofit/controller/ServiceController.java
+++ b/retrofit/src/main/java/com/xmartlabs/bigbang/retrofit/controller/ServiceController.java
@@ -6,7 +6,7 @@ import android.support.annotation.NonNull;
 import com.annimon.stream.Objects;
 import com.xmartlabs.bigbang.core.controller.Controller;
 import com.xmartlabs.bigbang.core.controller.EntityServiceProvider;
-import com.xmartlabs.bigbang.core.helper.IoSchedulersTransformationHelper;
+import com.xmartlabs.bigbang.core.helper.SchedulersTransformationHelper;
 import com.xmartlabs.bigbang.core.model.EntityWithId;
 
 import java.util.List;
@@ -46,7 +46,7 @@ public abstract class ServiceController<Id, E extends EntityWithId<Id>> extends 
   @Override
   public Maybe<E> getEntityFromList(@NonNull Single<List<E>> serviceCall, @NonNull Id id) {
     return serviceCall
-        .compose(IoSchedulersTransformationHelper.applySingleIoSchedulersTransformation())
+        .compose(SchedulersTransformationHelper.applySingleIoSchedulersTransformation())
         .toObservable()
         .flatMap(Observable::fromIterable)
         .filter(entity -> Objects.equals(entity, id))

--- a/retrofit/src/main/java/com/xmartlabs/bigbang/retrofit/controller/ServiceController.java
+++ b/retrofit/src/main/java/com/xmartlabs/bigbang/retrofit/controller/ServiceController.java
@@ -26,11 +26,10 @@ import io.reactivex.SingleTransformer;
 public abstract class ServiceController<Id, E extends EntityWithId<Id>> extends Controller
     implements EntityServiceProvider<Id, E> {
   @CheckResult
-  @Deprecated
   @NonNull
   @Override
   public CompletableTransformer applyCompletableServiceTransformation() {
-    return applyCompletableIoSchedulers();
+    return applyCompletableIoSchedulersTransformation();
   }
 
   @CheckResult
@@ -41,11 +40,10 @@ public abstract class ServiceController<Id, E extends EntityWithId<Id>> extends 
   }
 
   @CheckResult
-  @Deprecated
   @NonNull
   @Override
   public <S> SingleTransformer<S, S> applySingleServiceTransformation() {
-    return applySingleIoSchedulers();
+    return applySingleIoSchedulersTransformation();
   }
 
   @CheckResult

--- a/retrofit/src/main/java/com/xmartlabs/bigbang/retrofit/controller/ServiceController.java
+++ b/retrofit/src/main/java/com/xmartlabs/bigbang/retrofit/controller/ServiceController.java
@@ -6,13 +6,13 @@ import android.support.annotation.NonNull;
 import com.annimon.stream.Objects;
 import com.xmartlabs.bigbang.core.controller.Controller;
 import com.xmartlabs.bigbang.core.controller.EntityServiceProvider;
+import com.xmartlabs.bigbang.core.helper.IoSchedulersTransformationHelper;
 import com.xmartlabs.bigbang.core.model.EntityWithId;
 
 import java.util.List;
 
 import io.reactivex.CompletableTransformer;
 import io.reactivex.Maybe;
-import io.reactivex.MaybeTransformer;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.SingleTransformer;
@@ -26,24 +26,19 @@ import io.reactivex.SingleTransformer;
 public abstract class ServiceController<Id, E extends EntityWithId<Id>> extends Controller
     implements EntityServiceProvider<Id, E> {
   @CheckResult
-  @NonNull
-  @Override
-  public CompletableTransformer applyCompletableServiceTransformation() {
-    return applyCompletableIoSchedulersTransformation();
-  }
-
-  @CheckResult
-  @NonNull
-  @Override
-  public <S> MaybeTransformer<S, S> applyMaybeServiceTransformation() {
-    return applyMaybeIoSchedulersTransformation();
-  }
-
-  @CheckResult
+  @Deprecated
   @NonNull
   @Override
   public <S> SingleTransformer<S, S> applySingleServiceTransformation() {
-    return applySingleIoSchedulersTransformation();
+    return applySingleIoSchedulers();
+  }
+
+  @CheckResult
+  @Deprecated
+  @NonNull
+  @Override
+  public CompletableTransformer applyCompletableServiceTransformation() {
+    return applyCompletableIoSchedulers();
   }
 
   @CheckResult
@@ -51,7 +46,7 @@ public abstract class ServiceController<Id, E extends EntityWithId<Id>> extends 
   @Override
   public Maybe<E> getEntityFromList(@NonNull Single<List<E>> serviceCall, @NonNull Id id) {
     return serviceCall
-        .compose(applySingleServiceTransformation())
+        .compose(IoSchedulersTransformationHelper.applySingleIoSchedulersTransformation())
         .toObservable()
         .flatMap(Observable::fromIterable)
         .filter(entity -> Objects.equals(entity, id))

--- a/ui/src/main/java/com/xmartlabs/bigbang/ui/common/recyclerview/OnDemandLoadingScrollListener.java
+++ b/ui/src/main/java/com/xmartlabs/bigbang/ui/common/recyclerview/OnDemandLoadingScrollListener.java
@@ -1,4 +1,4 @@
-package com.xmartlabs.template.ui.common;
+package com.xmartlabs.bigbang.ui.common.recyclerview;
 
 import android.support.annotation.NonNull;
 import android.support.v7.widget.LinearLayoutManager;
@@ -10,7 +10,7 @@ import lombok.Setter;
  * An OnDemandLoadingScrollListener for recycler view pagination
  */
 public abstract class OnDemandLoadingScrollListener extends RecyclerView.OnScrollListener {
-  public static final int VISIBLE_THRESHOLD_DEFAULT = 5;
+  private static final int VISIBLE_THRESHOLD_DEFAULT = 5;
 
   private int previousTotal;
   private boolean loading = true;

--- a/ui/src/main/java/com/xmartlabs/bigbang/ui/common/recyclerview/OnDemandRecyclerViewScrollListener.java
+++ b/ui/src/main/java/com/xmartlabs/bigbang/ui/common/recyclerview/OnDemandRecyclerViewScrollListener.java
@@ -1,4 +1,4 @@
-package com.xmartlabs.template.ui.common;
+package com.xmartlabs.bigbang.ui.common.recyclerview;
 
 import android.support.annotation.Dimension;
 import android.support.annotation.NonNull;


### PR DESCRIPTION
* Adds new IO transformers (they subscribe and observe on the Io Schedulers)
* Deprecated old transformers as they observed on the main thread.
* New transformers are added in a new class, as static methods. That way you won't be forced to extend `ServiceController`

* Moved `OnDemandLoadingScrollListener` and `OnDemandRecyclerViewLoadingScrollListener` to the UI module (`common` package).

/cc @xmartlabs/android
